### PR TITLE
Authenticate user with the correct LDAP branch

### DIFF
--- a/rest/auth.py
+++ b/rest/auth.py
@@ -180,6 +180,13 @@ class User(object):
 
             # authenticate user on ldap
             user_dn = "uid=%s,%s" % (login, base_people)
+            # Retrieve user branch from LDAP
+            user_dns = conn.search_s(base_people,
+                                     ldap.SCOPE_SUBTREE,
+                                     "(uid=%s)" % login,
+                                     ['cn'])
+            if len(user_dns) > 0:
+                user_dn = user_dns[0][0]
             conn.simple_bind_s(user_dn, password)
 
             print "User %s authenticated" % login


### PR DESCRIPTION
When using LDAP with multiple branches, you first have to retrieve user branch using uid and bind it using this branch. If no branch is found, try to authenticate with the `base_people`branch defined in the config file.