### PR TITLE
Support slurmrestd jwt auth

### DIFF
--- a/conf/vendor/agent.yml
+++ b/conf/vendor/agent.yml
@@ -61,10 +61,16 @@ slurmrestd:
     type: str
     default: '0.0.39'
     doc: Slurm REST API version
-  slurm_token:
+  enable_jwt_auth:
+    type: bool
+    default: false
+    doc: Enable slurmrestd jwt authentication
+  jwt_auth_user:
     type: str
-    default: 'None'
-    doc: Slurm REST API authentication token
+    doc: slurmrestd authentication user
+  jwt_auth_token:
+    type: str
+    doc: slurmrestd authentication token
 
 filters:
   jobs:

--- a/conf/vendor/agent.yml
+++ b/conf/vendor/agent.yml
@@ -61,6 +61,10 @@ slurmrestd:
     type: str
     default: '0.0.39'
     doc: Slurm REST API version
+  slurm_token:
+    type: str
+    default: 'None'
+    doc: Slurm REST API authentication token
 
 filters:
   jobs:

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -91,3 +91,8 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
         else:
             logger.warning("Caching is disabled")
             self.cache = None
+        if self.settings.slurmrestd.slurm_token:
+            self.slurmrestd_headers = {'X-SLURM-USER-TOKEN': self.settings.slurmrestd.slurm_token}
+        else:
+            self.slurmrestd_headers = None
+

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -91,8 +91,11 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
         else:
             logger.warning("Caching is disabled")
             self.cache = None
-        if self.settings.slurmrestd.slurm_token:
-            self.slurmrestd_headers = {'X-SLURM-USER-TOKEN': self.settings.slurmrestd.slurm_token}
+        if self.settings.slurmrestd.enable_jwt_auth:
+            self.slurmrestd_headers = {
+                'X-SLURM-USER-NAME': self.settings.slurmrestd.jwt_auth_user,
+                'X-SLURM-USER-TOKEN': self.settings.slurmrestd.jwt_auth_token,
+            }
         else:
             self.slurmrestd_headers = None
 

--- a/slurmweb/views/agent.py
+++ b/slurmweb/views/agent.py
@@ -44,7 +44,7 @@ def slurmrest(query, key, handle_errors=True):
     prefix = "http+unix://slurmrestd/"
     session.mount(prefix, SlurmrestdUnixAdapter(current_app.settings.slurmrestd.socket))
     try:
-        response = session.get(f"{prefix}/{query}")
+        response = session.get(f"{prefix}/{query}", headers=current_app.slurmrestd_headers)
     except requests.exceptions.ConnectionError as err:
         logger.error("Unable to connect to slurmrestd: %s", err)
         abort(500, f"Unable to connect to slurmrestd: {err}")


### PR DESCRIPTION
Hello,
slurm-web does not currently support slurmrestd's jwt authentication (see [slurm docs](https://slurm.schedmd.com/slurmrestd.html#OPT_rest_auth/jwt)).
This pull request is a naive attempt to support it using the `X-SLURM-USER-*` request headers.
I tested it on our infrastructure which uses jwt authentication and it seems to work. 
Let me know what do you think of it.