### PR TITLE
Avoid KeyError with warnings on old unsupported Slurm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - frontend: Add intermediate cluster list width to 80% on large screens, before
   going down to 60% on even larger screens.
+- agent: Check Slurm version returned from `slurmrestd` against hard-coded
+  minimal version and log error if not greater or equal.
 - pkgs: Add requirement on RFL.core and RFL.authentication >= 1.0.3.
 - docs: Update configuration reference documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     interpreted by frontend and emit clear error message in logs (#321).
   - Detect responses from slurmrestd not formatted in JSON, translated into JSON
     error for frontend and emit clear error message in logs (#333).
+  - Detect absence of _warnings_ key in `slurmrestd` responses and emit warning
+    log instead of crashing (#316).
 - genjwt: fix portability to Python < 3.8 in debug message.
 - ldap-check: fix usage of `user_name_attribute` configuration parameter (#340).
 - frontend:

--- a/slurmweb/views/agent.py
+++ b/slurmweb/views/agent.py
@@ -92,7 +92,13 @@ def slurmrest(query, key, handle_errors=True):
                 error["description"],
                 error["source"],
             )
-    if len(result["warnings"]):
+    if "warnings" not in result:
+        logger.error(
+            "Unable to extract warnings from slurmrestd response to %s, unsupported "
+            "Slurm version?",
+            query,
+        )
+    elif len(result["warnings"]):
         logger.warning("slurmrestd query %s warnings: %s", query, result["warnings"])
     return result[key]
 


### PR DESCRIPTION
Also log clear error message to mention unsupported Slurm version.

fix #316