### PR TITLE
Refactor slurmrestd interface in agent

### DIFF
--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -15,6 +15,7 @@ from . import SlurmwebWebApp
 from ..version import get_version
 from ..views import SlurmwebAppRoute
 from ..views import agent as views
+from ..slurmrestd import Slurmrestd
 from ..cache import CachingService
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,8 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
         except RacksDBFormatError as err:
             logger.critical("Unable to load RacksDB database: %s", err)
             sys.exit(1)
+
+        self.slurmrestd = Slurmrestd(self.settings.slurmrestd.socket)
 
         if self.settings.policy.roles.exists():
             logger.debug("Select RBAC site roles policy %s", self.settings.policy.roles)

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -15,7 +15,7 @@ from . import SlurmwebWebApp
 from ..version import get_version
 from ..views import SlurmwebAppRoute
 from ..views import agent as views
-from ..slurmrestd import Slurmrestd
+from ..slurmrestd import SlurmrestdFiltered
 from ..cache import CachingService
 
 logger = logging.getLogger(__name__)
@@ -66,8 +66,10 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
             logger.critical("Unable to load RacksDB database: %s", err)
             sys.exit(1)
 
-        self.slurmrestd = Slurmrestd(
-            self.settings.slurmrestd.socket, self.settings.slurmrestd.version
+        self.slurmrestd = SlurmrestdFiltered(
+            self.settings.slurmrestd.socket,
+            self.settings.slurmrestd.version,
+            self.settings.filters,
         )
 
         if self.settings.policy.roles.exists():

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -66,7 +66,9 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
             logger.critical("Unable to load RacksDB database: %s", err)
             sys.exit(1)
 
-        self.slurmrestd = Slurmrestd(self.settings.slurmrestd.socket)
+        self.slurmrestd = Slurmrestd(
+            self.settings.slurmrestd.socket, self.settings.slurmrestd.version
+        )
 
         if self.settings.policy.roles.exists():
             logger.debug("Select RBAC site roles policy %s", self.settings.policy.roles)

--- a/slurmweb/errors.py
+++ b/slurmweb/errors.py
@@ -23,15 +23,3 @@ class SlurmwebAuthenticationError(Exception):
 
 class SlurmwebCacheError(Exception):
     pass
-
-
-class SlurmwebRestdError(Exception):
-    def __init__(self, message, error, description, source):
-        super().__init__(message)
-        self.message = message
-        self.error = error
-        self.description = description
-        self.source = source
-
-    def __str__(self):
-        return f"SlurwebRestdError({self.message}, {self.error}, {self.description}, {self.source})"

--- a/slurmweb/slurmrestd/__init__.py
+++ b/slurmweb/slurmrestd/__init__.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Rackslab
+#
+# This file is part of Slurm-web.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+import logging
+
+import requests
+
+from .unix import SlurmrestdUnixAdapter
+from .errors import (
+    SlurmrestdNotFoundError,
+    SlurmrestdInvalidResponseError,
+    SlurmrestConnectionError,
+    SlurmrestdInternalError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Slurmrestd:
+
+    def __init__(self, socket: Path):
+        self.session = requests.Session()
+        self.prefix = "http+unix://slurmrestd/"
+        self.session.mount(self.prefix, SlurmrestdUnixAdapter(socket))
+
+    def _validate_response(self, response, ignore_notfound) -> None:
+        """Validate slurmrestd response or abort agent resquest with error."""
+        self._validate_status(response, ignore_notfound)
+        self._validate_json(response)
+
+    def _validate_status(self, response, ignore_notfound) -> None:
+        """Check response status code is not HTTP/404 or abort"""
+        if ignore_notfound:
+            return
+        if response.status_code != 404:
+            return
+        raise SlurmrestdNotFoundError(response.url)
+
+    def _validate_json(self, response) -> None:
+        """Check json reponse or abort with HTTP/500"""
+        content_type = response.headers.get("content-type")
+        if content_type != "application/json":
+            logger.debug(
+                "slurmrestd query %s response: %s", response.url, response.text
+            )
+            raise SlurmrestdInvalidResponseError(
+                f"Unsupported Content-Type for slurmrestd response {response.url}: "
+                f"{content_type}"
+            )
+
+    def request(self, query, key, ignore_notfound=False):
+        try:
+            response = self.session.get(f"{self.prefix}/{query}")
+        except requests.exceptions.ConnectionError as err:
+            raise SlurmrestConnectionError(str(err))
+
+        self._validate_response(response, ignore_notfound)
+
+        result = response.json()
+        if len(result["errors"]):
+            error = result["errors"][0]
+            raise SlurmrestdInternalError(
+                error.get("error", "slurmrestd undefined error"),
+                error.get("error_number", -1),
+                error["description"],
+                error["source"],
+            )
+        if "warnings" not in result:
+            logger.error(
+                "Unable to extract warnings from slurmrestd response to %s, unsupported "
+                "Slurm version?",
+                query,
+            )
+        elif len(result["warnings"]):
+            logger.warning(
+                "slurmrestd query %s warnings: %s", query, result["warnings"]
+            )
+        return result[key]

--- a/slurmweb/slurmrestd/__init__.py
+++ b/slurmweb/slurmrestd/__init__.py
@@ -104,9 +104,14 @@ class Slurmrestd:
         return self._request(f"/slurm/v{self.api_version}/nodes", "nodes", **kwargs)
 
     def node(self, node_name: str, **kwargs):
-        return self._request(
-            f"/slurm/v{self.api_version}/node/{node_name}", "nodes", **kwargs
-        )
+        try:
+            return self._request(
+                f"/slurm/v{self.api_version}/node/{node_name}", "nodes", **kwargs
+            )[0]
+        except SlurmrestdInternalError as err:
+            if err.description.startswith("Failure to query node "):
+                raise SlurmrestdNotFoundError(f"Node {node_name} not found")
+            raise err
 
     def partitions(self, **kwargs):
         return self._request(

--- a/slurmweb/slurmrestd/errors.py
+++ b/slurmweb/slurmrestd/errors.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Rackslab
+#
+# This file is part of Slurm-web.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class SlurmrestConnectionError(Exception):
+    pass
+
+
+class SlurmrestdNotFoundError(Exception):
+    pass
+
+
+class SlurmrestdInvalidResponseError(Exception):
+    pass
+
+
+class SlurmrestdInternalError(Exception):
+    def __init__(self, message, error, description, source):
+        super().__init__(message)
+        self.message = message
+        self.error = error
+        self.description = description
+        self.source = source
+
+    def __str__(self):
+        return f"SlurwebRestdError({self.message}, {self.error}, {self.description}, {self.source})"

--- a/slurmweb/slurmrestd/unix.py
+++ b/slurmweb/slurmrestd/unix.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 Rackslab
+#
+# This file is part of Slurm-web.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import socket
+import logging
+
+from urllib3.connection import HTTPConnection
+from urllib3.connectionpool import HTTPConnectionPool
+from requests.adapters import HTTPAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class SlurmrestdUnixConnection(HTTPConnection):
+    def __init__(self, path):
+        super().__init__("localhost")
+        self.path = path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        logger.debug("Connecting to unix socket %s", self.path)
+        self.sock.connect(str(self.path))
+
+
+class SlurmrestdUnixConnectionPool(HTTPConnectionPool):
+    def __init__(self, path):
+        super().__init__("localhost")
+        self.path = path
+
+    def _new_conn(self):
+        return SlurmrestdUnixConnection(self.path)
+
+
+class SlurmrestdUnixAdapter(HTTPAdapter):
+    def __init__(self, path):
+        super().__init__()
+        self.path = path
+
+    # Required by Requests >= 2.32.2. For reference:
+    # https://github.com/psf/requests/pull/6710
+    #
+    # As mentionned by Requests maintainers, this is backwards compatible between
+    # versions of Requests.
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        return self.get_connection(request.url, proxies)
+
+    def get_connection(self, url, proxies=None):
+        return SlurmrestdUnixConnectionPool(self.path)

--- a/slurmweb/tests/test_agent.py
+++ b/slurmweb/tests/test_agent.py
@@ -140,7 +140,7 @@ class TestAgent(unittest.TestCase):
     #
 
     def test_request_slurmrestd_connection_error(self):
-        self.app.slurmrestd.request = mock.Mock(
+        self.app.slurmrestd._request = mock.Mock(
             side_effect=SlurmrestConnectionError("connection error")
         )
         response = self.client.get(f"/v{get_version()}/jobs")
@@ -155,7 +155,7 @@ class TestAgent(unittest.TestCase):
         )
 
     def test_request_slurmrestd_invalid_type(self):
-        self.app.slurmrestd.request = mock.Mock(
+        self.app.slurmrestd._request = mock.Mock(
             side_effect=SlurmrestdInvalidResponseError("invalid type")
         )
         response = self.client.get(f"/v{get_version()}/jobs")

--- a/slurmweb/tests/test_agent.py
+++ b/slurmweb/tests/test_agent.py
@@ -348,7 +348,7 @@ class TestAgent(unittest.TestCase):
             response.json,
             {
                 "code": 404,
-                "description": "Job 1 not found",
+                "description": "URL not found on slurmrestd: Job 1 not found",
                 "name": "Not Found",
             },
         )

--- a/slurmweb/tests/test_agent.py
+++ b/slurmweb/tests/test_agent.py
@@ -467,7 +467,7 @@ class TestAgent(unittest.TestCase):
             response.json,
             {
                 "code": 404,
-                "description": "Node not-found not found",
+                "description": "URL not found on slurmrestd: Node not-found not found",
                 "name": "Not Found",
             },
         )

--- a/slurmweb/tests/test_slurmrestd.py
+++ b/slurmweb/tests/test_slurmrestd.py
@@ -12,13 +12,15 @@ import os
 import requests
 
 from rfl.settings import RuntimeSettings
-from slurmweb.slurmrestd import Slurmrestd, SlurmrestdFiltered
+from slurmweb.slurmrestd import Slurmrestd, SlurmrestdFiltered, SlurmrestdFilteredCached
 from slurmweb.slurmrestd.errors import (
     SlurmrestConnectionError,
     SlurmrestdInternalError,
     SlurmrestdInvalidResponseError,
     SlurmrestdNotFoundError,
 )
+from slurmweb.cache import CachingService
+from slurmweb.errors import SlurmwebCacheError
 
 from .utils import (
     all_slurm_versions,
@@ -31,6 +33,13 @@ class TestSlurmrestdBase(unittest.TestCase):
 
     def mock_slurmrestd_responses(self, slurm_version, assets):
         return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
+
+    def load_agent_settings_definition(self):
+        return RuntimeSettings.yaml_definition(
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "conf", "vendor", "agent.yml"
+            )
+        )
 
 
 class TestSlurmrestd(TestSlurmrestdBase):
@@ -219,11 +228,7 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
 class TestSlurmrestdFiltered(TestSlurmrestdBase):
     def setUp(self):
-        self.settings = RuntimeSettings.yaml_definition(
-            os.path.join(
-                os.path.dirname(__file__), "..", "..", "conf", "vendor", "agent.yml"
-            )
-        )
+        self.settings = self.load_agent_settings_definition()
         self.slurmrestd = SlurmrestdFiltered(
             Path("/dev/null"), "1.0.0", self.settings.filters
         )
@@ -363,3 +368,96 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
             # Check arbitrary key has been filtered out.
             self.assertIn("usage_threshold", asset[idx])
             self.assertNotIn("usage_threshold", qos[idx])
+
+
+class TestSlurmrestdFilteredCached(TestSlurmrestdBase):
+    def setUp(self):
+        self.settings = self.load_agent_settings_definition()
+        self.settings.cache.enabled = True
+        self.cache = CachingService(
+            self.settings.cache.host,
+            self.settings.cache.port,
+            self.settings.cache.password,
+        )
+        self.slurmrestd = SlurmrestdFilteredCached(
+            Path("/dev/null"),
+            "1.0.0",
+            self.settings.filters,
+            self.settings.cache,
+            self.cache,
+        )
+
+    @all_slurm_versions
+    def test_not_in_cache(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        self.slurmrestd.service.get = mock.Mock(return_value=None)
+        self.slurmrestd.service.put = mock.Mock()
+        jobs = self.slurmrestd.jobs()
+        for idx in range(len(jobs)):
+            self.assertEqual(jobs[idx]["job_id"], asset[idx]["job_id"])
+        # Check SlurmrestdFilteredCached has tried to get jobs from cache
+        self.slurmrestd.service.get.assert_called_once_with("jobs")
+        # Check SlurmrestdFilteredCached has up jobs in cache with corresponding
+        # expiration timeout.
+        self.slurmrestd.service.put.assert_called_once_with(
+            "jobs", jobs, self.settings.cache.jobs
+        )
+
+    @all_slurm_versions
+    def test_in_cache(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        self.slurmrestd.service.get = mock.Mock(return_value=asset)
+        self.slurmrestd.service.put = mock.Mock()
+        jobs = self.slurmrestd.jobs()
+        for idx in range(len(jobs)):
+            self.assertEqual(jobs[idx]["job_id"], asset[idx]["job_id"])
+        # Check SlurmrestdFilteredCached has tried to get jobs from cache.
+        self.slurmrestd.service.get.assert_called_once_with("jobs")
+        # Check SlurmrestdFilteredCached has not put jobs again in cache.
+        self.slurmrestd.service.put.assert_not_called()
+
+    @all_slurm_versions
+    def test_cache_get_error(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        # Check behaviour when SlurmwebCacheError in raised at get()
+        self.slurmrestd.service.get = mock.Mock(
+            side_effect=SlurmwebCacheError("fake cache error")
+        )
+        self.slurmrestd.service.put = mock.Mock()
+        with self.assertRaisesRegex(SlurmwebCacheError, "^fake cache error$"):
+            self.slurmrestd.jobs()
+        self.slurmrestd.service.get.assert_called_once_with("jobs")
+        self.slurmrestd.service.put.assert_not_called()
+
+    @all_slurm_versions
+    def test_cache_put_error(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        # Check behaviour when SlurmwebCacheError in raised at put()
+        self.slurmrestd.service.get = mock.Mock(return_value=None)
+        self.slurmrestd.service.put = mock.Mock(
+            side_effect=SlurmwebCacheError("fake cache error")
+        )
+        with self.assertRaisesRegex(SlurmwebCacheError, "^fake cache error$"):
+            self.slurmrestd.jobs()
+        self.slurmrestd.service.get.assert_called_once_with("jobs")
+        self.slurmrestd.service.put.assert_called_once()

--- a/slurmweb/tests/test_slurmrestd.py
+++ b/slurmweb/tests/test_slurmrestd.py
@@ -27,7 +27,7 @@ from .utils import (
 
 class TestSlurmrestd(unittest.TestCase):
     def setUp(self):
-        self.slurmrestd = Slurmrestd(Path("/dev/null"))
+        self.slurmrestd = Slurmrestd(Path("/dev/null"), "1.0.0")
 
     def mock_slurmrestd_responses(self, slurm_version, assets):
         return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
@@ -41,7 +41,7 @@ class TestSlurmrestd(unittest.TestCase):
             )
         except SlurmwebAssetUnavailable:
             return
-        response = self.slurmrestd.request("/whatever", key="jobs")
+        response = self.slurmrestd._request("/whatever", key="jobs")
         self.assertEqual(response, asset)
 
     def test_request_connection_error(self):
@@ -52,7 +52,7 @@ class TestSlurmrestd(unittest.TestCase):
             SlurmrestConnectionError,
             "^test connection error$",
         ):
-            self.slurmrestd.request("/whatever", key="whatever")
+            self.slurmrestd._request("/whatever", key="whatever")
 
     @all_slurm_versions
     def test_request_slurm_internal_error(self, slurm_version):
@@ -69,7 +69,7 @@ class TestSlurmrestd(unittest.TestCase):
             r"^SlurwebRestdError\(slurmrestd undefined error, -1, Failure to query "
             r"node unexisting-node, _dump_nodes\)$",
         ):
-            self.slurmrestd.request("/whatever", key="whatever")
+            self.slurmrestd._request("/whatever", key="whatever")
 
     def test_request_slurm_invalid_content_type(self):
         fake_response = requests.Response()
@@ -81,7 +81,7 @@ class TestSlurmrestd(unittest.TestCase):
             SlurmrestdInvalidResponseError,
             "^Unsupported Content-Type for slurmrestd response None: text/plain$",
         ):
-            self.slurmrestd.request("/whatever", key="whatever")
+            self.slurmrestd._request("/whatever", key="whatever")
 
     @all_slurm_versions
     def test_request_slurm_not_found(self, slurm_version):
@@ -94,4 +94,4 @@ class TestSlurmrestd(unittest.TestCase):
             return
 
         with self.assertRaisesRegex(SlurmrestdNotFoundError, "^/mocked/query$"):
-            self.slurmrestd.request("/whatever", key="whatever")
+            self.slurmrestd._request("/whatever", key="whatever")

--- a/slurmweb/tests/test_slurmrestd.py
+++ b/slurmweb/tests/test_slurmrestd.py
@@ -95,3 +95,115 @@ class TestSlurmrestd(unittest.TestCase):
 
         with self.assertRaisesRegex(SlurmrestdNotFoundError, "^/mocked/query$"):
             self.slurmrestd._request("/whatever", key="whatever")
+
+    @all_slurm_versions
+    def test_version(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-ping", "meta")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        version = self.slurmrestd.version()
+        self.assertCountEqual(version, asset["Slurm"])
+
+    @all_slurm_versions
+    def test_jobs(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        jobs = self.slurmrestd.jobs()
+        self.assertCountEqual(jobs, asset)
+
+    @all_slurm_versions
+    def test_nodes(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-nodes", "nodes")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        nodes = self.slurmrestd.nodes()
+        self.assertCountEqual(nodes, asset)
+
+    @all_slurm_versions
+    def test_node(self, slurm_version):
+        # We can use slurm-node-allocated asset for this test.
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-node-allocated", "nodes")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        node = self.slurmrestd.node("node1")
+        self.assertCountEqual(node, asset[0])
+
+    @all_slurm_versions
+    def test_node_not_found(self, slurm_version):
+        # We can use slurm-node-unfound asset for this test.
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-node-unfound", None)]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        with self.assertRaisesRegex(
+            SlurmrestdNotFoundError, "^Node unknown not found$"
+        ):
+            self.slurmrestd.node("unknown")
+
+    @all_slurm_versions
+    def test_partitions(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-partitions", "partitions")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        partitions = self.slurmrestd.partitions()
+        self.assertCountEqual(partitions, asset)
+
+    @all_slurm_versions
+    def test_accounts(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-accounts", "accounts")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        accounts = self.slurmrestd.accounts()
+        self.assertCountEqual(accounts, asset)
+
+    @all_slurm_versions
+    def test_reservations(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-reservations", "reservations")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        reservations = self.slurmrestd.reservations()
+        self.assertCountEqual(reservations, asset)
+
+    @all_slurm_versions
+    def test_qos(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-qos", "qos")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        qos = self.slurmrestd.qos()
+        self.assertCountEqual(qos, asset)

--- a/slurmweb/tests/test_slurmrestd.py
+++ b/slurmweb/tests/test_slurmrestd.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 Rackslab
+#
+# This file is part of Slurm-web.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import requests
+
+from slurmweb.slurmrestd import Slurmrestd
+from slurmweb.slurmrestd.errors import (
+    SlurmrestConnectionError,
+    SlurmrestdInternalError,
+    SlurmrestdInvalidResponseError,
+    SlurmrestdNotFoundError,
+)
+
+from .utils import (
+    all_slurm_versions,
+    SlurmwebAssetUnavailable,
+    mock_slurmrestd_responses,
+)
+
+
+class TestSlurmrestd(unittest.TestCase):
+    def setUp(self):
+        self.slurmrestd = Slurmrestd(Path("/dev/null"))
+
+    def mock_slurmrestd_responses(self, slurm_version, assets):
+        return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
+
+    @all_slurm_versions
+    def test_request(self, slurm_version):
+        # We can use basically any successful asset such as slurm-jobs for this test.
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        response = self.slurmrestd.request("/whatever", key="jobs")
+        self.assertEqual(response, asset)
+
+    def test_request_connection_error(self):
+        self.slurmrestd.session.get = mock.Mock(
+            side_effect=requests.exceptions.ConnectionError("test connection error")
+        )
+        with self.assertRaisesRegex(
+            SlurmrestConnectionError,
+            "^test connection error$",
+        ):
+            self.slurmrestd.request("/whatever", key="whatever")
+
+    @all_slurm_versions
+    def test_request_slurm_internal_error(self, slurm_version):
+        # We can use slurm-node-unfound asset for this test.
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-node-unfound", "nodes")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        with self.assertRaisesRegex(
+            SlurmrestdInternalError,
+            r"^SlurwebRestdError\(slurmrestd undefined error, -1, Failure to query "
+            r"node unexisting-node, _dump_nodes\)$",
+        ):
+            self.slurmrestd.request("/whatever", key="whatever")
+
+    def test_request_slurm_invalid_content_type(self):
+        fake_response = requests.Response()
+        fake_response.headers = {"content-type": "text/plain"}
+        fake_response.json = lambda: "whatever"
+        self.slurmrestd.session.get = mock.Mock(return_value=fake_response)
+
+        with self.assertRaisesRegex(
+            SlurmrestdInvalidResponseError,
+            "^Unsupported Content-Type for slurmrestd response None: text/plain$",
+        ):
+            self.slurmrestd.request("/whatever", key="whatever")
+
+    @all_slurm_versions
+    def test_request_slurm_not_found(self, slurm_version):
+        # We can use slurm-not-found asset for this test.
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-not-found", None)]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+
+        with self.assertRaisesRegex(SlurmrestdNotFoundError, "^/mocked/query$"):
+            self.slurmrestd.request("/whatever", key="whatever")

--- a/slurmweb/tests/test_slurmrestd.py
+++ b/slurmweb/tests/test_slurmrestd.py
@@ -7,10 +7,12 @@
 import unittest
 from unittest import mock
 from pathlib import Path
+import os
 
 import requests
 
-from slurmweb.slurmrestd import Slurmrestd
+from rfl.settings import RuntimeSettings
+from slurmweb.slurmrestd import Slurmrestd, SlurmrestdFiltered
 from slurmweb.slurmrestd.errors import (
     SlurmrestConnectionError,
     SlurmrestdInternalError,
@@ -25,7 +27,13 @@ from .utils import (
 )
 
 
-class TestSlurmrestd(unittest.TestCase):
+class TestSlurmrestdBase(unittest.TestCase):
+
+    def mock_slurmrestd_responses(self, slurm_version, assets):
+        return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
+
+
+class TestSlurmrestd(TestSlurmrestdBase):
     def setUp(self):
         self.slurmrestd = Slurmrestd(Path("/dev/null"), "1.0.0")
 
@@ -207,3 +215,151 @@ class TestSlurmrestd(unittest.TestCase):
 
         qos = self.slurmrestd.qos()
         self.assertCountEqual(qos, asset)
+
+
+class TestSlurmrestdFiltered(TestSlurmrestdBase):
+    def setUp(self):
+        self.settings = RuntimeSettings.yaml_definition(
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "conf", "vendor", "agent.yml"
+            )
+        )
+        self.slurmrestd = SlurmrestdFiltered(
+            Path("/dev/null"), "1.0.0", self.settings.filters
+        )
+
+    @all_slurm_versions
+    def test_jobs(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-jobs", "jobs")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        jobs = self.slurmrestd.jobs()
+        for idx in range(len(jobs)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(jobs[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(jobs[idx]["job_id"], asset[idx]["job_id"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("accrue_time", asset[idx])
+            self.assertNotIn("accrue_time", jobs[idx])
+
+    @all_slurm_versions
+    def test_job(self, slurm_version):
+        try:
+            [slurmdb_asset, slurm_asset] = self.mock_slurmrestd_responses(
+                slurm_version,
+                [("slurmdb-job-running", "jobs"), ("slurm-job-running", "jobs")],
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        job = self.slurmrestd.job(1)
+        # Check there are less keys for the item in result than in original asset.
+        print(slurm_asset)
+        self.assertLess(len(job.keys()), len(slurm_asset[0].keys()))
+        self.assertEqual(job["time"], slurmdb_asset[0]["time"])
+        # Check arbitrary key has been filtered out.
+        self.assertIn("array_job_id", slurm_asset[0])
+        self.assertNotIn("array_job_id", job)
+
+    @all_slurm_versions
+    def test_nodes(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-nodes", "nodes")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        nodes = self.slurmrestd.nodes()
+        for idx in range(len(nodes)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(nodes[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(nodes[idx]["name"], asset[idx]["name"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("specialized_cpus", asset[idx])
+            self.assertNotIn("specialized_cpus", nodes[idx])
+
+    @all_slurm_versions
+    def test_node(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-node-idle", "nodes")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        node = self.slurmrestd.node("node1")
+        # Check there are less keys for the item in result than in original asset.
+        self.assertLess(len(node.keys()), len(asset[0].keys()))
+        self.assertEqual(node["name"], asset[0]["name"])
+        # Check arbitrary key has been filtered out.
+        self.assertIn("specialized_cpus", asset[0])
+        self.assertNotIn("specialized_cpus", node)
+
+    @all_slurm_versions
+    def test_partitions(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-partitions", "partitions")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        partitions = self.slurmrestd.partitions()
+        for idx in range(len(partitions)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(partitions[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(partitions[idx]["name"], asset[idx]["name"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("suspend_time", asset[idx])
+            self.assertNotIn("suspend_time", partitions[idx])
+
+    @all_slurm_versions
+    def test_accounts(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-accounts", "accounts")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        accounts = self.slurmrestd.accounts()
+        for idx in range(len(accounts)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(accounts[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(accounts[idx]["name"], asset[idx]["name"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("flags", asset[idx])
+            self.assertNotIn("flags", accounts[idx])
+
+    @all_slurm_versions
+    def test_reservations(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-reservations", "reservations")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        reservations = self.slurmrestd.reservations()
+        for idx in range(len(reservations)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(reservations[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(reservations[idx]["name"], asset[idx]["name"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("core_specializations", asset[idx])
+            self.assertNotIn("core_specializations", reservations[idx])
+
+    @all_slurm_versions
+    def test_qos(self, slurm_version):
+        try:
+            [asset] = self.mock_slurmrestd_responses(
+                slurm_version, [("slurm-qos", "qos")]
+            )
+        except SlurmwebAssetUnavailable:
+            return
+        qos = self.slurmrestd.qos()
+        for idx in range(len(qos)):
+            # Check there are less keys for the 1st item in result than in original asset.
+            self.assertLess(len(qos[idx].keys()), len(asset[idx].keys()))
+            self.assertEqual(qos[idx]["name"], asset[idx]["name"])
+            # Check arbitrary key has been filtered out.
+            self.assertIn("usage_threshold", asset[idx])
+            self.assertNotIn("usage_threshold", qos[idx])

--- a/slurmweb/tests/utils.py
+++ b/slurmweb/tests/utils.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 Rackslab
+#
+# This file is part of Slurm-web.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from unittest import mock
+import warnings
+from pathlib import Path
+import json
+import copy
+
+import requests
+
+ASSETS = Path(__file__).parent.resolve() / ".." / "tests" / "assets"
+
+
+def slurm_versions():
+    for path in (ASSETS / "slurmrestd").iterdir():
+        yield path.name
+
+
+def load_asset(path: Path):
+    with open(ASSETS / path) as f:
+        return f.read()
+
+
+def load_json_asset(path: Path):
+    with open(ASSETS / path) as f:
+        return json.load(f)
+
+
+def all_slurm_versions(test):
+    """Split test with a subtest for every slurm versions"""
+
+    def inner(self, *args, **kwargs):
+        for slurm_version in slurm_versions():
+            with self.subTest(
+                msg=f"slurm {slurm_version}", slurm_version=slurm_version
+            ):
+                test(self, slurm_version, *args, **kwargs)
+
+    return inner
+
+
+class SlurmwebAssetUnavailable(Exception):
+    pass
+
+
+def mock_slurmrestd_responses(slurmrestd, slurm_version, assets):
+    responses = []
+    results = []
+
+    with open(ASSETS / f"slurmrestd/{slurm_version}/status.json") as fh:
+        requests_statuses = json.load(fh)
+
+    for asset_name, key in assets:
+        if asset_name not in requests_statuses:
+            warnings.warn(
+                f"Unable to find asset {asset_name} in requests status file for Slurm "
+                f"{slurm_version}"
+            )
+            raise SlurmwebAssetUnavailable()
+
+        is_json = True
+        if requests_statuses[asset_name]["content-type"] == "application/json":
+            asset = load_json_asset(f"slurmrestd/{slurm_version}/{asset_name}.json")
+            # Copy asset as it is modified during test processing and we need to keep
+            # original value for comparison.
+            original = copy.deepcopy(asset)
+        else:
+            is_json = False
+            asset = load_asset(f"slurmrestd/{slurm_version}/{asset_name}.txt")
+            original = asset
+        fake_response = mock.create_autospec(requests.Response)
+        fake_response.url = "/mocked/query"
+        fake_response.status_code = requests_statuses[asset_name]["status"]
+        fake_response.headers = {
+            "content-type": requests_statuses[asset_name]["content-type"]
+        }
+        if is_json:
+            fake_response.json = mock.Mock(return_value=asset)
+        else:
+            fake_response.text = mock.PropertyMock(return_value=asset)
+        responses.append(fake_response)
+        if key is not None:
+            results.append(original[key])
+        else:
+            results.append(original)
+
+    if len(responses) > 1:
+        slurmrestd.session.get = mock.Mock(side_effect=responses)
+    else:
+        slurmrestd.session.get = mock.Mock(return_value=responses[0])
+
+    return results

--- a/slurmweb/views/__init__.py
+++ b/slurmweb/views/__init__.py
@@ -4,55 +4,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import socket
-import logging
-
-from urllib3.connection import HTTPConnection
-from urllib3.connectionpool import HTTPConnectionPool
-from requests.adapters import HTTPAdapter
-
-logger = logging.getLogger(__name__)
-
 
 class SlurmwebAppRoute:
     def __init__(self, endpoint: str, func, methods=None):
         self.endpoint = endpoint
         self.func = func
         self.methods = methods
-
-
-class SlurmrestdUnixConnection(HTTPConnection):
-    def __init__(self, path):
-        super().__init__("localhost")
-        self.path = path
-
-    def connect(self):
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        logger.debug("Connecting to unix socket %s", self.path)
-        self.sock.connect(str(self.path))
-
-
-class SlurmrestdUnixConnectionPool(HTTPConnectionPool):
-    def __init__(self, path):
-        super().__init__("localhost")
-        self.path = path
-
-    def _new_conn(self):
-        return SlurmrestdUnixConnection(self.path)
-
-
-class SlurmrestdUnixAdapter(HTTPAdapter):
-    def __init__(self, path):
-        super().__init__()
-        self.path = path
-
-    # Required by Requests >= 2.32.2. For reference:
-    # https://github.com/psf/requests/pull/6710
-    #
-    # As mentionned by Requests maintainers, this is backwards compatible between
-    # versions of Requests.
-    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
-        return self.get_connection(request.url, proxies)
-
-    def get_connection(self, url, proxies=None):
-        return SlurmrestdUnixConnectionPool(self.path)

--- a/slurmweb/views/agent.py
+++ b/slurmweb/views/agent.py
@@ -164,26 +164,6 @@ def _get_job(job):
     return result
 
 
-def _get_node(name):
-    try:
-        return filter_fields(
-            current_app.settings.filters.node,
-            slurmrest,
-            "node",
-            (name,),
-            True,
-        )[0]
-    except SlurmrestdInternalError as err:
-        if err.description.startswith("Failure to query node "):
-            msg = f"Node {name} not found"
-            logger.warning(msg)
-            abort(404, msg)
-        else:
-            msg = f"slurmrestd errors: {str(err)}"
-            logger.error(msg)
-            abort(500, msg)
-
-
 def _cached_job(job):
     return _cached_data(
         f"job-{job}",
@@ -208,8 +188,9 @@ def _cached_node(name):
     return _cached_data(
         f"node-{name}",
         current_app.settings.cache.node,
-        _get_node,
-        name,
+        slurmrest,
+        "node",
+        (name,),
     )
 
 

--- a/slurmweb/views/agent.py
+++ b/slurmweb/views/agent.py
@@ -13,7 +13,7 @@ from rfl.web.tokens import rbac_action, check_jwt
 
 from ..version import get_version
 from ..errors import SlurmwebCacheError, SlurmwebRestdError
-from . import SlurmrestdUnixAdapter
+from ..slurmrestd.unix import SlurmrestdUnixAdapter
 
 # Tuple used for comparaison with Slurm version retrieved from slurmrestd and
 # check for minimal supported version.


### PR DESCRIPTION
Introduce `Slurmrestd` class, with `SlurmrestdFiltered` and `SlurmrestdFilteredCached` to manage respectively interface with `slurmrestd`, keys filtering and cache layer.