### PR TITLE
Change agent info fields parsing error message to reflect new response content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add requirement on markdown external library for `gateway` extra package.
 
 ### Changed
+- gateway: Change error message when unable to parse agent info fields.
 - docs:
   - Update configuration reference documentation.
   - Update dashboard screenshot in overview page with example of resource chart.

--- a/slurmweb/apps/gateway.py
+++ b/slurmweb/apps/gateway.py
@@ -36,7 +36,7 @@ class SlurmwebAgent:
             return cls(data["cluster"], data["infrastructure"], data["metrics"], url)
         except KeyError as err:
             raise SlurmwebAgentError(
-                "Unable to retrieve cluster name from agent"
+                "Unable to parse cluster info fields from agent"
             ) from err
 
 

--- a/slurmweb/tests/test_gateway.py
+++ b/slurmweb/tests/test_gateway.py
@@ -97,8 +97,8 @@ class TestGatewayApp(TestGatewayBase):
             cm.output,
             [
                 "ERROR:slurmweb.apps.gateway:Unable to retrieve agent info from url "
-                "http://localhost: [SlurmwebAgentError] Unable to retrieve cluster "
-                "name from agent"
+                "http://localhost: [SlurmwebAgentError] Unable to parse cluster info "
+                "fields from agent"
             ],
         )
 


### PR DESCRIPTION
It is not only about the name of the cluster.