### PR TITLE
tests(agent): authd users w/o anonymous role

### DIFF
--- a/slurmweb/tests/views/test_agent.py
+++ b/slurmweb/tests/views/test_agent.py
@@ -56,7 +56,7 @@ class TestAgentViews(TestAgentBase):
         self.assertEqual(len(response.json.keys()), 2)
         self.assertIn("actions", response.json)
         self.assertIn("roles", response.json)
-        self.assertCountEqual(response.json["roles"], ["user", "anonymous"])
+        self.assertCountEqual(response.json["roles"], ["user"])
 
     #
     # General error cases


### PR DESCRIPTION
Since RFL v1.2.0, authenticated users do not inherit anonymous role by default anymore.