### PR TITLE
Fix ModuleNotFoundError: No module named 'werkzeug.middleware' on el8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
           pip install PyYAML==5.4.1
           echo "::notice::Installing PyJWT (old version)"
           pip install PyJWT==2.4.0
+          echo "::notice::Installing Werkzeug (old version)"
+          pip install "Werkzeug<0.13"
           echo "::notice::Installing Flask (old version)"
-          pip install "flask<2.1.0"
+          pip install "flask<1.0"
           echo "::notice::Installing requests (old version)"
           pip install "requests<2.26.0"
           echo "::notice::Installing pyasn1 (old version)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: Update configuration reference documentation.
 
 ### Fixed
+- agent: Fix No module named 'werkzeug.middleware' ModuleNotFoundError with
+  Werkzeug < 0.15 (#419→420).
 - frontend: Update dependencies to fix CVE-2024-55565 (nanoid).
 
 ## [4.0.0] - 2024-11-28

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -10,7 +10,15 @@ import logging
 from rfl.web.tokens import RFLTokenizedRBACWebApp
 from racksdb.errors import RacksDBSchemaError, RacksDBFormatError
 from racksdb.web.app import RacksDBWebBlueprint
-from werkzeug.middleware import dispatcher
+
+try:
+    from werkzeug.middleware import dispatcher
+except ModuleNotFoundError:
+    # In Werkzeug < 0.15, dispatcher was not in a dedicated module, it was included in a
+    # big wsgi module. This old version of werkzeug must be fully supported because it
+    # is included in el8. See https://github.com/rackslab/Slurm-web/issues/419 for
+    # reference.
+    from werkzeug import wsgi as dispatcher
 
 from . import SlurmwebWebApp
 from ..version import get_version

--- a/slurmweb/tests/lib/agent.py
+++ b/slurmweb/tests/lib/agent.py
@@ -103,11 +103,12 @@ class TestAgentBase(unittest.TestCase):
             ),
             duration=3600,
         )
-        # werkzeug.test.TestResponse class does not have text property in
-        # werkzeug <= 2.1. When such version is installed, use custom test
-        # response class to backport this text property.
+        # werkzeug.test.TestResponse class does not have text and json
+        # properties in werkzeug <= 0.15. When such version is installed, use
+        # custom test response class to backport these text and json properties.
         try:
             getattr(werkzeug.test.TestResponse, "text")
+            getattr(werkzeug.test.TestResponse, "json")
         except AttributeError:
             self.app.response_class = SlurmwebCustomTestResponse
         self.client = self.app.test_client()

--- a/slurmweb/tests/lib/utils.py
+++ b/slurmweb/tests/lib/utils.py
@@ -100,11 +100,17 @@ def mock_slurmrestd_responses(slurmrestd, slurm_version, assets):
 
 class SlurmwebCustomTestResponse(flask.Response):
     """Custom flask Response class to backport text property of
-    werkzeug.test.TestResponse class on werkzeug < 2.1 on Python 3.6."""
+    werkzeug.test.TestResponse class on werkzeug < 0.15."""
 
     @property
     def text(self):
         return self.get_data(as_text=True)
+
+    @property
+    def json(self):
+        if self.mimetype != "application/json":
+            return None
+        return json.loads(self.text)
 
 
 def fake_text_response():

--- a/slurmweb/tests/views/test_agent.py
+++ b/slurmweb/tests/views/test_agent.py
@@ -119,17 +119,14 @@ class TestAgentViews(TestAgentBase):
     def test_request_agent_not_found(self):
         response = self.client.get("/fail")
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(
-            response.json,
-            {
-                "code": 404,
-                "description": (
-                    "The requested URL was not found on the server. If you entered "
-                    "the URL manually please check your spelling and try again."
-                ),
-                "name": "Not Found",
-            },
+
+        self.assertEqual(response.json["code"], 404)
+        self.assertRegex(
+            response.json["description"],
+            r"^The requested URL was not found on the server.\s? If you entered the "
+            r"URL manually please check your spelling and try again.$",
         )
+        self.assertEqual(response.json["name"], "Not Found")
 
     def test_access_denied(self):
         # Test agent permission denied with @rbac_action decorator by calling /accounts

--- a/slurmweb/tests/views/test_gateway.py
+++ b/slurmweb/tests/views/test_gateway.py
@@ -19,11 +19,12 @@ from ..lib.utils import SlurmwebCustomTestResponse
 class TestGatewayViews(TestGatewayBase):
     def setUp(self):
         self.setup_app()
-        # werkzeug.test.TestResponse class does not have text property in
-        # werkzeug <= 2.1. When such version is installed, use custom test
-        # response class to backport this text property.
+        # werkzeug.test.TestResponse class does not have text and json
+        # properties in werkzeug <= 0.15. When such version is installed, use
+        # custom test response class to backport these text and json properties.
         try:
             getattr(werkzeug.test.TestResponse, "text")
+            getattr(werkzeug.test.TestResponse, "json")
         except AttributeError:
             self.app.response_class = SlurmwebCustomTestResponse
         self.client = self.app.test_client()


### PR DESCRIPTION
This PR tracks the work to fix #419.