### PR TITLE
fix(front): split JS chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     infrastructure graphical representation from RacksDB.
   - Restore infrastructure graphical representation canvas on cluster change in
     resources page when coming from cluster on which RacksDB failed.
+  - Reduce size of JS chunk by moving _chart.js_ and _luxon_ libraries in
+    separate _vendor_ chunk (#414→#441).
   - Update dependencies to fix CVE-2024-55565 (nanoid).
 
 ## [4.0.0] - 2024-11-28

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Rackslab
+ * Copyright (c) 2023-2025 Rackslab
  *
  * This file is part of Slurm-web.
  *
@@ -26,6 +26,14 @@ export default defineConfig({
     }
   },
   build: {
-    target: 'esnext'  // required for top-level await used by runtimeConfiguration plugin
+    target: 'esnext',  // required for top-level await used by runtimeConfiguration plugin
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['chart.js', 'luxon'],
+        }
+      }
+    }
+
   }
 })


### PR DESCRIPTION
Reduce size of JS chunk by moving chart.js and luxon libraries in separate vendor chunk.

fix #414