### PR TITLE
refactor(front): remove firefox blurry workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     resources page when coming from cluster on which RacksDB failed.
   - Reduce size of JS chunk by moving _chart.js_ and _luxon_ libraries in
     separate _vendor_ chunk (#414→#441).
+  - Remove workaround for Firefox to avoid blurry lines in racks canvas, fixed
+    in Firefox ESR >= 128 and Firefox >= 133 (#443).
   - Update dependencies to fix CVE-2024-55565 (nanoid).
 
 ## [4.0.0] - 2024-11-28

--- a/frontend/src/components/resources/ResourcesCanvas.vue
+++ b/frontend/src/components/resources/ResourcesCanvas.vue
@@ -32,7 +32,6 @@ const props = defineProps({
   }
 })
 
-const isFirefox = navigator.userAgent.includes('Firefox')
 const emit = defineEmits(['imageSize'])
 const unable = defineModel({ required: true, default: false })
 
@@ -160,8 +159,8 @@ async function updateCanvas(fullUpdate: boolean = true) {
       // Draw all nodes using their coordinates
       for (const [nodeName, nodeCoordinates] of Object.entries(coordinates)) {
         const nodePath = new Path2D()
-        const node_x = nodeCoordinates[0] + x_shift + 1 - (isFirefox ? 0 : 0.5)
-        const node_y = nodeCoordinates[1] + y_shift - (isFirefox ? 0 : 0.5)
+        const node_x = nodeCoordinates[0] + x_shift + 0.5
+        const node_y = nodeCoordinates[1] + y_shift - 0.5
         nodePath.rect(node_x, node_y, nodeCoordinates[2] - 1, nodeCoordinates[3])
 
         if (!inSelectedNodes(nodeName)) {
@@ -182,8 +181,8 @@ async function updateCanvas(fullUpdate: boolean = true) {
               ctx.lineWidth = 2
             }
             ctx.strokeRect(
-              nodeCoordinates[0] + x_shift + ctx.lineWidth / 2 + 1 - (isFirefox ? 0 : 0.5),
-              nodeCoordinates[1] + y_shift + ctx.lineWidth / 2 - (isFirefox ? 0 : 0.5),
+              nodeCoordinates[0] + x_shift + ctx.lineWidth / 2 + 0.5,
+              nodeCoordinates[1] + y_shift + ctx.lineWidth / 2 - 0.5,
               nodeCoordinates[2] - ctx.lineWidth - 1,
               nodeCoordinates[3] - ctx.lineWidth
             )


### PR DESCRIPTION
Remove workaround for Firefox to avoid blurry lines in racks canvas, fixed in Firefox ESR >= 128 and Firefox >= 133. For reference, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1847681