### PR TITLE
chore(ci): run apt update before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install tests dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev libcairo2-dev libgirepository1.0-dev libpango1.0-dev
           python -m pip install --upgrade pip
 


### PR DESCRIPTION
During some runs, apt-get install fails on 404 due to packages not found in remote ubuntu repositories. This is generally due to out-of-date repository metadata and is fixed by a simple update.