### PR TITLE
fix(front): npm audit fix vite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     separate _vendor_ chunk (#414→#441).
   - Remove workaround for Firefox to avoid blurry lines in racks canvas, fixed
     in Firefox ESR >= 128 and Firefox >= 133 (#443).
-  - Update dependencies to fix CVE-2024-55565 (nanoid).
+  - Update dependencies to fix CVE-2024-55565 (nanoid) and CVE-2025-24010
+    (vite).
 
 ## [4.0.0] - 2024-11-28
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6425,9 +6425,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+      "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -6927,9 +6927,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -7532,9 +7532,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.5.4",
-    "vite": "^4.5.4",
+    "vite": "^4.5.9",
     "vitest": "^1.4.0",
     "vue-router-mock": "^1.1.0",
     "vue-tsc": "^2.0.29"


### PR DESCRIPTION
Fix the following security issue:

  vite  <=4.5.5 || 5.0.0 - 5.4.11
  Severity: moderate
  Websites were able to send any requests to the development server and
  read the response in vite -
  https://github.com/advisories/GHSA-vg6x-rcgg-rjx6