### PR TITLE
docs: fix cp uwsgi services command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (vite).
 - pkgs: Bump dependency to RFL.web 1.3.0 to fix access to restricted endpoints
   with anonymous token or no token (#460,#462→#461).
+- docs: Fix cp command to copy examples of uWSGI services provided in Slurm-web
+  packages (#448→#465).
 
 ## [4.0.0] - 2024-11-28
 

--- a/docs/modules/conf/partials/uwsgi-services-http.adoc
+++ b/docs/modules/conf/partials/uwsgi-services-http.adoc
@@ -2,7 +2,7 @@ Copy examples of uWSGI services provided in Slurm-web packages:
 
 [source,console]
 ----
-# cp -v /usr/share/slurm-web/wsgi/agent/slurm-web-{agent,gateway}-uwsgi.service /etc/systemd/system/
+# cp -v /usr/share/slurm-web/wsgi/*/slurm-web-{agent,gateway}-uwsgi.service /etc/systemd/system/
 ----
 
 Edit [.path]#`/etc/systemd/system/slurm-web-gateway-uwsgi.service`# to force

--- a/docs/modules/conf/partials/uwsgi-services.adoc
+++ b/docs/modules/conf/partials/uwsgi-services.adoc
@@ -2,8 +2,7 @@ Copy examples of uWSGI services provided in Slurm-web packages and reload units:
 
 [source,console]
 ----
-# cp -v /usr/share/slurm-web/wsgi/agent/slurm-web-{gateway,agent}-uwsgi.service \
-  /etc/systemd/system/
+# cp -v /usr/share/slurm-web/wsgi/*/slurm-web-{agent,gateway}-uwsgi.service /etc/systemd/system/
 # systemctl daemon-reload
 ----
 


### PR DESCRIPTION
Fix cp command to copy examples of uWSGI services provided in Slurm-web packages.

fix #448