### PR TITLE
chore: add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve the software
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions**
+Please give the output of these commands:
+
+* On RHEL, CentOS, Rocky Linux, AlmaLinux and Fedora:
+```console
+$ rpm -qa | egrep 'slurm|racksdb|rfl'
+```
+
+* On Debian and Ubuntu:
+```console
+$ dpkg -l | egrep 'slurm|racksdb|rfl'
+```
+
+**Additional context**
+Add any other context about the problem here (ex: error messages in logs).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support
+    url: https://github.com/rackslab/Slurm-web/discussions/categories/q-a
+    about: Please ask your questions in Q&A section of GitHub Discussions.
+  - name: Professional Support
+    url: https://rackslab.io/en/contact/
+    about: For entreprise professional support with SLA, request a quote from Rackslab.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add initial version of issue templates in order to restrict issues to actual bugs and feature requests, and route questions to Q&A section of GitHub discussions.