### PR TITLE
fix(front): add bearer token in racksdb request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- front: missing bearer token in RacksDB infrastructure diagram request (#471).
+
 ## [4.1.0] - 2025-02-05
 
 ### Added

--- a/frontend/src/composables/GatewayAPI.ts
+++ b/frontend/src/composables/GatewayAPI.ts
@@ -456,7 +456,7 @@ export function useGatewayAPI() {
 
   async function login(idents: loginIdents): Promise<GatewayLoginResponse> {
     try {
-      return (await restAPI.post('/login', idents)) as GatewayLoginResponse
+      return (await restAPI.post('/login', idents, false)) as GatewayLoginResponse
     } catch (error: any) {
       /* Translate 401 APIServerError into AuthenticationError */
       if (error instanceof APIServerError && error.status == 401) {
@@ -468,7 +468,7 @@ export function useGatewayAPI() {
 
   async function anonymousLogin(): Promise<GatewayAnonymousLoginResponse> {
     try {
-      return (await restAPI.get('/anonymous')) as GatewayAnonymousLoginResponse
+      return (await restAPI.get('/anonymous', false)) as GatewayAnonymousLoginResponse
     } catch (error: any) {
       /* Translate 401 APIServerError into AuthenticationError */
       if (error instanceof APIServerError && error.status == 401) {
@@ -479,7 +479,7 @@ export function useGatewayAPI() {
   }
 
   async function message_login(): Promise<string> {
-    return await restAPI.get<string>(`/messages/login`)
+    return await restAPI.get<string>('/messages/login', false)
   }
 
   async function clusters(): Promise<Array<ClusterDescription>> {
@@ -567,7 +567,7 @@ export function useGatewayAPI() {
         dimensions: { width: width, height: height },
         infrastructure: { equipment_labels: false, ghost_unselected: true }
       },
-      false,
+      true,
       'arraybuffer'
     )
     // parse multipart response with Response.formData()


### PR DESCRIPTION
Add missing bearer token in RacksDB infrastructure diagram request, it is now required by @check_jwt decorator on the gateway endpoint with RFL >= 1.3.0 to avoid HTTP/403 response.

The token is removed from request headers for login (incl. anonymous) and login service message at the same time, as the client does not have JWT at this stage yet and the gateway does not enforce the presence of the bearer token for the corresponding endpoints.

fix #471