### PR TITLE
chore(ci): add system dep for PyGObject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
           sudo apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev libcairo2-dev libgirepository1.0-dev libpango1.0-dev
           python -m pip install --upgrade pip
 
+      # New version of PyGObject 3.52.1 (RacksDB dependency) depends on
+      #libgirepository-2.0-dev, which is available in ubuntu >= 24.04 only.
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt-get install -y libgirepository-2.0-dev
+
       - name: Install application with its dependencies
         if: ${{ matrix.python-version != '3.6' }}
         run: |


### PR DESCRIPTION
New version of PyGObject 3.52.1 (RacksDB dependency) depends on libgirepository-2.0-dev on ubuntu-latest, then install it in build environment.