### PR TITLE
fix: deprecation warning on pkg_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - conf: Update description of `agent` > `racksdb_version` to describe its new
   semantic.
 - docs: Update configuration reference documentation.
+- pkgs: Add dependency on `importlib_metadata` external library on Python < 3.8.
 
 ### Fixed
+- Fix _DeprecationWarning_ with setuptools `pkg_resources` being used as an API.
 - agent: Fix compatibility issue with Requests >= 2.32.2 (#350).
 - frontend:
   - Missing bearer token in RacksDB infrastructure diagram request (#471).

--- a/slurmweb/version.py
+++ b/slurmweb/version.py
@@ -4,8 +4,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import pkg_resources
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 
 def get_version():
-    return pkg_resources.get_distribution("slurm-web").version
+    return metadata.version("slurm-web")


### PR DESCRIPTION
Use standard library importlib.metadata to retrieve package version instead of using setuptools pkg_resources which raises DeprecationWarning 'pkg_resources is deprecated as an API' with setuptools >= 67.

Unfortunately, importlib.metadata is only available starting with Python 3.8. On older versions of Python, importlib_metadata backport external library is used, which adds new dependency on these old versions of Python.