### PR TITLE
chore(ci): fix pyasn1 dep error on python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           pip install "flask<1.0"
           echo "::notice::Installing requests (old version)"
           pip install "requests<2.26.0"
-          echo "::notice::Installing pyasn1 (old version)"
-          pip install "pyasn1<0.6.0"
+          echo "::notice::Installing python-ldap (old version)"
+          pip install "python-ldap<3.4"
           echo "::notice::Installing markdown (old version)"
           pip install "markdown<3"
 


### PR DESCRIPTION
This error now raises on Python 3.6:

  error: pyasn1 0.5.1 is installed but pyasn1<0.7.0,>=0.6.1 is required
  by {'pyasn1-modules'}

The pyasn1 dependency is due to python-ldap. Try to fix it by installing an older version of python-ldap, similarly to el8.