### PR TITLE
refactor(front): ignore canceled requests errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - frontend:
   - Missing bearer token in RacksDB infrastructure diagram request (#471).
   - Responsive layout in jobs view by removing some columns on smaller screens.
+  - Do not display canceled request errors (#507).
   - Update dependencies to fix CVE-2025-24964 (vitest), CVE-2025-27152 (axios)
     CVE-2025-30208 (vite) and GHSA-67mh-4wv8-2f99 (esbuild).
 

--- a/frontend/src/composables/DataGetter.ts
+++ b/frontend/src/composables/DataGetter.ts
@@ -9,7 +9,7 @@
 import { ref, watch, onMounted } from 'vue'
 import type { Ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { AuthenticationError, PermissionError } from '@/composables/HTTPErrors'
+import { AuthenticationError, PermissionError, CanceledRequestError } from '@/composables/HTTPErrors'
 import { useGatewayAPI } from '@/composables/GatewayAPI'
 import type { GatewayGenericAPIKey, GatewayAnyClusterApiKey } from '@/composables/GatewayAPI'
 import { useRuntimeStore } from '@/stores/runtime'
@@ -54,7 +54,8 @@ export function useGatewayDataGetter<Type>(
         reportAuthenticationError(error)
       } else if (error instanceof PermissionError) {
         reportPermissionError(error)
-      } else {
+      } else if (!(error instanceof CanceledRequestError)) {
+        /* Ignore canceled requests errors */
         if (customErrorHandler) {
           customErrorHandler(error)
         } else {

--- a/frontend/src/composables/DataPoller.ts
+++ b/frontend/src/composables/DataPoller.ts
@@ -9,7 +9,7 @@
 import { ref, onUnmounted, onMounted, watch } from 'vue'
 import type { Ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { AuthenticationError, PermissionError } from '@/composables/HTTPErrors'
+import { AuthenticationError, PermissionError, CanceledRequestError } from '@/composables/HTTPErrors'
 import { useGatewayAPI } from '@/composables/GatewayAPI'
 import type { GatewayAnyClusterApiKey } from '@/composables/GatewayAPI'
 import { useRuntimeStore } from '@/stores/runtime'
@@ -76,7 +76,8 @@ export function useClusterDataPoller<Type>(
           reportAuthenticationError(error)
         } else if (error instanceof PermissionError) {
           reportPermissionError(error, cluster)
-        } else {
+        } else if (!(error instanceof CanceledRequestError)) {
+          /* Ignore canceled requests errors */
           reportOtherError(error)
         }
       }

--- a/frontend/src/composables/HTTPErrors.ts
+++ b/frontend/src/composables/HTTPErrors.ts
@@ -31,3 +31,9 @@ export class RequestError extends Error {
     super(message)
   }
 }
+
+export class CanceledRequestError extends Error {
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/frontend/src/composables/RESTAPI.ts
+++ b/frontend/src/composables/RESTAPI.ts
@@ -5,6 +5,7 @@ import {
   AuthenticationError,
   PermissionError,
   APIServerError,
+  CanceledRequestError,
   RequestError
 } from '@/composables/HTTPErrors'
 
@@ -56,6 +57,9 @@ export function useRESTAPI() {
         }
       } else if (error.request) {
         /* No reply from server */
+        //console.log(error)
+        if (error.code == "ERR_CANCELED")
+          throw new CanceledRequestError('Canceled request')
         throw new RequestError(`Request error: ${error.message}`)
       } else {
         /* Something else happening when setting up the request */


### PR DESCRIPTION
Do not display canceled requests errors to end users, they are expected and add no value for users.

fix #507