### PR TITLE
refactor(front): main menu entry as prop

### DIFF
--- a/frontend/src/components/ClusterMainLayout.vue
+++ b/frontend/src/components/ClusterMainLayout.vue
@@ -23,7 +23,8 @@ type BreadcrumbPart = {
   routeName?: string
 }
 
-const { cluster, breadcrumb } = defineProps<{
+const { menuEntry, cluster, breadcrumb } = defineProps<{
+  menuEntry: string
   cluster: string
   breadcrumb: BreadcrumbPart[]
 }>()
@@ -41,7 +42,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <MainMenu />
+  <MainMenu :entry="menuEntry" />
   <div class="lg:pl-72">
     <div
       class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white shadow-sm sm:gap-x-6 lg:px-4"

--- a/frontend/src/components/MainMenu.vue
+++ b/frontend/src/components/MainMenu.vue
@@ -21,6 +21,10 @@ import {
 
 import { useRuntimeStore } from '@/stores/runtime'
 
+const { entry } = defineProps<{
+  entry: string
+}>()
+
 const runtimeStore = useRuntimeStore()
 const navigation = [
   { name: 'Dashboard', route: 'dashboard', icon: HomeIcon, permission: 'view-stats' },
@@ -97,7 +101,7 @@ const navigation = [
                           v-if="runtimeStore.hasPermission(item.permission)"
                           :to="{ name: item.route }"
                           :class="[
-                            item.route == runtimeStore.navigation
+                            item.route == entry
                               ? 'bg-slurmweb-dark text-white'
                               : 'text-slurmweb-font-disabled hover:text-white',
                             'group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6'
@@ -106,7 +110,7 @@ const navigation = [
                           <component
                             :is="item.icon"
                             :class="[
-                              item.route == runtimeStore.navigation
+                              item.route == entry
                                 ? 'text-white'
                                 : 'text-slurmweb-font-disabled group-hover:text-white',
                               'h-6 w-6 shrink-0'
@@ -155,7 +159,7 @@ const navigation = [
                   v-if="runtimeStore.hasPermission(item.permission)"
                   :to="{ name: item.route }"
                   :class="[
-                    item.route == runtimeStore.navigation
+                    item.route == entry
                       ? 'bg-slurmweb-dark text-white'
                       : 'hover:slurmweb-dark text-slurmweb-font-disabled hover:text-white',
                     'group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6'

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -92,19 +92,13 @@ const router = createRouter({
           path: 'dashboard',
           name: 'dashboard',
           component: DashboardView,
-          props: true,
-          meta: {
-            entry: 'dashboard'
-          }
+          props: true
         },
         {
           path: 'jobs',
           name: 'jobs',
           component: JobsView,
-          props: true,
-          meta: {
-            entry: 'jobs'
-          }
+          props: true
         },
         {
           path: 'job/:id',
@@ -113,46 +107,31 @@ const router = createRouter({
           props: (route: RouteLocation) => ({
             cluster: route.params.cluster,
             id: parseInt(route.params.id as string)
-          }),
-          meta: {
-            entry: 'jobs'
-          }
+          })
         },
         {
           path: 'resources',
           name: 'resources',
           component: ResourcesView,
-          props: true,
-          meta: {
-            entry: 'resources'
-          }
+          props: true
         },
         {
           path: 'node/:nodeName',
           name: 'node',
           component: NodeView,
-          props: true,
-          meta: {
-            entry: 'resources'
-          }
+          props: true
         },
         {
           path: 'qos',
           name: 'qos',
           component: QosView,
-          props: true,
-          meta: {
-            entry: 'qos'
-          }
+          props: true
         },
         {
           path: 'reservations',
           name: 'reservations',
           component: ReservationsView,
-          props: true,
-          meta: {
-            entry: 'reservations'
-          }
+          props: true
         }
       ]
     }
@@ -179,7 +158,6 @@ router.beforeEach(async (to, from) => {
       return '/anonymous'
     }
   }
-  runtime.navigation = to.meta.entry as string
   runtime.routePath = to.path as string
   runtime.sidebarOpen = false
 

--- a/frontend/src/stores/runtime.ts
+++ b/frontend/src/stores/runtime.ts
@@ -53,7 +53,6 @@ export interface RuntimeStore {
 }
 
 export const useRuntimeStore = defineStore('runtime', () => {
-  const navigation: Ref<string> = ref('home')
   const routePath: Ref<string> = ref('/')
   const beforeSettingsRoute: Ref<RouteLocation | undefined> = ref(undefined)
 
@@ -120,7 +119,6 @@ export const useRuntimeStore = defineStore('runtime', () => {
     addNotification(new Notification('INFO', message, 5))
   }
   return {
-    navigation,
     routePath,
     beforeSettingsRoute,
     dashboard,

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -22,7 +22,11 @@ const { data, unable } = useClusterDataPoller<ClusterStats>('stats', 10000)
 </script>
 
 <template>
-  <ClusterMainLayout :cluster="cluster" :breadcrumb="[{ title: 'Dashboard' }]">
+  <ClusterMainLayout
+    menu-entry="dashboard"
+    :cluster="cluster"
+    :breadcrumb="[{ title: 'Dashboard' }]"
+  >
     <div class="mx-auto max-w-7xl bg-white">
       <ErrorAlert v-if="unable"
         >Unable to retrieve statistics from cluster

--- a/frontend/src/views/JobView.vue
+++ b/frontend/src/views/JobView.vue
@@ -185,6 +185,7 @@ onMounted(() => {
 
 <template>
   <ClusterMainLayout
+    menu-entry="jobs"
     :cluster="cluster"
     :breadcrumb="[{ title: 'Jobs', routeName: 'jobs' }, { title: `Job ${id}` }]"
   >

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -227,7 +227,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ClusterMainLayout :cluster="cluster" :breadcrumb="[{ title: 'Jobs' }]">
+  <ClusterMainLayout menu-entry="jobs" :cluster="cluster" :breadcrumb="[{ title: 'Jobs' }]">
     <div class="bg-white">
       <JobsFiltersPanel :cluster="cluster" :nb-jobs="sortedJobs.length" />
       <div class="mx-auto flex items-center justify-between">

--- a/frontend/src/views/NodeView.vue
+++ b/frontend/src/views/NodeView.vue
@@ -45,6 +45,7 @@ if (runtimeStore.hasPermission('view-jobs')) {
 
 <template>
   <ClusterMainLayout
+    menu-entry="resources"
     :cluster="cluster"
     :breadcrumb="[{ title: 'Resources', routeName: 'resources' }, { title: `Node ${nodeName}` }]"
   >

--- a/frontend/src/views/QosView.vue
+++ b/frontend/src/views/QosView.vue
@@ -103,7 +103,7 @@ function qosResourcesLimits(qos: ClusterQos) {
 </script>
 
 <template>
-  <ClusterMainLayout :cluster="cluster" :breadcrumb="[{ title: 'QOS' }]">
+  <ClusterMainLayout menu-entry="qos" :cluster="cluster" :breadcrumb="[{ title: 'QOS' }]">
     <div class="mx-auto flex items-center justify-between">
       <div class="px-4 py-16 sm:px-6 lg:px-8">
         <h1 class="text-3xl font-bold tracking-tight text-gray-900">QOS</h1>

--- a/frontend/src/views/ReservationsView.vue
+++ b/frontend/src/views/ReservationsView.vue
@@ -21,7 +21,11 @@ const { data, unable } = useClusterDataPoller<ClusterReservation[]>('reservation
 </script>
 
 <template>
-  <ClusterMainLayout :cluster="cluster" :breadcrumb="[{ title: 'Reservations' }]">
+  <ClusterMainLayout
+    menu-entry="reservations"
+    :cluster="cluster"
+    :breadcrumb="[{ title: 'Reservations' }]"
+  >
     <div class="mx-auto flex items-center justify-between">
       <div class="px-4 py-16 sm:px-6 lg:px-8">
         <h1 class="text-3xl font-bold tracking-tight text-gray-900">Reservations</h1>

--- a/frontend/src/views/ResourcesView.vue
+++ b/frontend/src/views/ResourcesView.vue
@@ -160,7 +160,11 @@ onMounted(() => {
 </script>
 
 <template>
-  <ClusterMainLayout :cluster="cluster" :breadcrumb="[{ title: 'Resources' }]">
+  <ClusterMainLayout
+    menu-entry="resources"
+    :cluster="cluster"
+    :breadcrumb="[{ title: 'Resources' }]"
+  >
     <div class="bg-white">
       <ResourcesFiltersPanel :cluster="cluster" :nbNodes="filteredNodes.length" />
 


### PR DESCRIPTION
Simply use a prop to control main meny entry instead of a route meta checked by route guard to fill runtime store.