### PR TITLE
fix(lib): missing conf seed log_component argument

### DIFF
--- a/lib/wsgi/agent/slurm-web-agent.py
+++ b/lib/wsgi/agent/slurm-web-agent.py
@@ -13,6 +13,7 @@ application = SlurmwebAppAgent(
     SlurmwebConfSeed(
         debug=False,
         log_flags=["ALL"],
+        log_component=None,
         debug_flags=[],
         conf_defs=SlurmwebAppAgent.SETTINGS_DEFINITION,
         conf=SlurmwebAppAgent.SITE_CONFIGURATION,

--- a/lib/wsgi/gateway/slurm-web-gateway.py
+++ b/lib/wsgi/gateway/slurm-web-gateway.py
@@ -13,6 +13,7 @@ application = SlurmwebAppGateway(
     SlurmwebConfSeed(
         debug=False,
         log_flags=["ALL"],
+        log_component=None,
         debug_flags=[],
         conf_defs=SlurmwebAppGateway.SETTINGS_DEFINITION,
         conf=SlurmwebAppGateway.SITE_CONFIGURATION,


### PR DESCRIPTION
Add missing SlurmwebConfSeed log_component argument in WSGI scripts. Regression introduced with 6100516.