### PR TITLE
chore(ci): disable py3.6 tests on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,10 @@ jobs:
         include:
           - os: "ubuntu-22.04"
             python-version: "3.7"
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
+          # ubuntu-20.04 runners are disabled in GitHub actions, Python 3.6 must
+          # be disabled until we find a solution.
+          #- os: "ubuntu-20.04"
+          #  python-version: "3.6"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions dropped support of ubuntu-20.04 runners, there is no obvious solution anymore to setup python 3.6. Tests on this environment are disabled until a durable solution is found.