### PR TITLE
Use parameterized to test all versions of Slurm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             python3-flask \
             python3-importlib-metadata \
             python3-markdown \
+            python3-parameterized \
             python3-pip \
             python3-prometheus_client \
             python3-pytest \
@@ -166,6 +167,7 @@ jobs:
             python3-clustershell \
             python3-flask \
             python3-markdown \
+            python3-parameterized \
             python3-pip \
             python3-prometheus-client \
             python3-pytest \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ gateway = [
 ]
 tests = [
     "pytest",
+    "parameterized",
     "pytest-cov",
     "coverage",
 ]

--- a/slurmweb/tests/lib/agent.py
+++ b/slurmweb/tests/lib/agent.py
@@ -21,6 +21,7 @@ from racksdb.errors import RacksDBFormatError, RacksDBSchemaError
 
 from .utils import (
     mock_slurmrestd_responses,
+    SlurmwebAssetUnavailable,
     SlurmwebCustomTestResponse,
 )
 
@@ -82,7 +83,10 @@ class FakeRacksDBWebBlueprint(Blueprint):
 
 class TestSlurmrestdClient(unittest.TestCase):
     def mock_slurmrestd_responses(self, slurm_version, assets):
-        return mock_slurmrestd_responses(self.app.slurmrestd, slurm_version, assets)
+        try:
+            return mock_slurmrestd_responses(self.app.slurmrestd, slurm_version, assets)
+        except SlurmwebAssetUnavailable as err:
+            self.skipTest(str(err))
 
 
 class TestAgentBase(TestSlurmrestdClient):

--- a/slurmweb/tests/lib/slurmrestd.py
+++ b/slurmweb/tests/lib/slurmrestd.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from rfl.settings import RuntimeSettings
 
-from .utils import mock_slurmrestd_responses
+from .utils import mock_slurmrestd_responses, SlurmwebAssetUnavailable
 from slurmweb.slurmrestd.auth import SlurmrestdAuthentifier
 
 
@@ -27,7 +27,10 @@ def basic_authentifier():
 
 class TestSlurmrestdBase(unittest.TestCase):
     def mock_slurmrestd_responses(self, slurm_version, assets):
-        return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
+        try:
+            return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
+        except SlurmwebAssetUnavailable as err:
+            self.skipTest(str(err))
 
     def load_agent_settings_definition(self):
         return RuntimeSettings.yaml_definition(

--- a/slurmweb/tests/slurmrestd/test_slurmrestd.py
+++ b/slurmweb/tests/slurmrestd/test_slurmrestd.py
@@ -19,11 +19,7 @@ from slurmweb.slurmrestd.errors import (
     SlurmrestdInvalidResponseError,
     SlurmrestdNotFoundError,
 )
-from ..lib.utils import (
-    all_slurm_versions,
-    SlurmwebAssetUnavailable,
-    mock_slurmrestd_responses,
-)
+from ..lib.utils import all_slurm_versions
 from ..lib.slurmrestd import TestSlurmrestdBase, basic_authentifier
 
 
@@ -35,18 +31,13 @@ class TestSlurmrestd(TestSlurmrestdBase):
             "1.0.0",
         )
 
-    def mock_slurmrestd_responses(self, slurm_version, assets):
-        return mock_slurmrestd_responses(self.slurmrestd, slurm_version, assets)
-
     @all_slurm_versions
     def test_request(self, slurm_version):
         # We can use basically any successful asset such as slurm-jobs for this test.
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
+
         response = self.slurmrestd._request("/whatever", key="jobs")
         self.assertEqual(response, asset)
 
@@ -63,12 +54,7 @@ class TestSlurmrestd(TestSlurmrestdBase):
     @all_slurm_versions
     def test_request_slurm_internal_error(self, slurm_version):
         # We can use slurm-node-unfound asset for this test.
-        try:
-            self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-unfound", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        self.mock_slurmrestd_responses(slurm_version, [("slurm-node-unfound", None)])
 
         with self.assertRaisesRegex(
             SlurmrestdInternalError,
@@ -92,48 +78,36 @@ class TestSlurmrestd(TestSlurmrestdBase):
     @all_slurm_versions
     def test_request_slurm_not_found(self, slurm_version):
         # We can use slurm-not-found asset for this test.
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-not-found", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-not-found", None)]
+        )
 
         with self.assertRaisesRegex(SlurmrestdNotFoundError, "^/mocked/query$"):
             self.slurmrestd._request("/whatever", key="whatever")
 
     @all_slurm_versions
     def test_request_slurm_jwt_missing_headers(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jwt-missing-headers", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jwt-missing-headers", None)]
+        )
 
         with self.assertRaisesRegex(SlurmrestdAuthenticationError, "^/mocked/query$"):
             self.slurmrestd._request("/whatever", key="whatever")
 
     @all_slurm_versions
     def test_request_slurm_jwt_invalid_headers(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jwt-invalid-headers", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jwt-invalid-headers", None)]
+        )
 
         with self.assertRaisesRegex(SlurmrestdAuthenticationError, "^/mocked/query$"):
             self.slurmrestd._request("/whatever", key="whatever")
 
     @all_slurm_versions
     def test_request_slurm_jwt_invalid_token(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jwt-invalid-token", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jwt-invalid-token", None)]
+        )
 
         with self.assertRaisesRegex(
             SlurmrestdInternalError, r"^SlurwebRestdError\(.*\)$"
@@ -142,12 +116,9 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_request_slurm_jwt_expired_token(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jwt-expired-token", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jwt-expired-token", None)]
+        )
 
         with self.assertRaisesRegex(
             SlurmrestdInternalError, r"^SlurwebRestdError\(.*\)$"
@@ -156,36 +127,27 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_version(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-ping", "meta")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-ping", "meta")]
+        )
 
         version = self.slurmrestd.version()
         self.assertCountEqual(version, asset["slurm"])
 
     @all_slurm_versions
     def test_jobs(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
 
         jobs = self.slurmrestd.jobs()
         self.assertCountEqual(jobs, asset)
 
     @all_slurm_versions
     def test_jobs_by_node(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
 
         def terminated(job):
             for terminated_state in ["COMPLETED", "FAILED", "TIMEOUT"]:
@@ -221,12 +183,9 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_jobs_states(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
 
         jobs, total = self.slurmrestd.jobs_states()
         # Check total value matches the number of jobs in asset
@@ -241,24 +200,18 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_nodes(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-nodes", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-nodes", "nodes")]
+        )
 
         nodes = self.slurmrestd.nodes()
         self.assertCountEqual(nodes, asset)
 
     @all_slurm_versions
     def test_resources_states(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-nodes", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-nodes", "nodes")]
+        )
 
         (
             nodes_states,
@@ -295,12 +248,10 @@ class TestSlurmrestd(TestSlurmrestdBase):
     @all_slurm_versions
     def test_node(self, slurm_version):
         # We can use slurm-node-allocated asset for this test.
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-allocated", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-allocated", "nodes")]
+        )
 
         node = self.slurmrestd.node("node1")
         self.assertCountEqual(node, asset[0])
@@ -308,12 +259,9 @@ class TestSlurmrestd(TestSlurmrestdBase):
     @all_slurm_versions
     def test_node_not_found(self, slurm_version):
         # We can use slurm-node-unfound asset for this test.
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-unfound", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-unfound", None)]
+        )
 
         with self.assertRaisesRegex(
             SlurmrestdNotFoundError, "^Node unknown not found$"
@@ -322,48 +270,34 @@ class TestSlurmrestd(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_partitions(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-partitions", "partitions")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-partitions", "partitions")]
+        )
 
         partitions = self.slurmrestd.partitions()
         self.assertCountEqual(partitions, asset)
 
     @all_slurm_versions
     def test_accounts(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-accounts", "accounts")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-accounts", "accounts")]
+        )
 
         accounts = self.slurmrestd.accounts()
         self.assertCountEqual(accounts, asset)
 
     @all_slurm_versions
     def test_reservations(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-reservations", "reservations")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-reservations", "reservations")]
+        )
 
         reservations = self.slurmrestd.reservations()
         self.assertCountEqual(reservations, asset)
 
     @all_slurm_versions
     def test_qos(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-qos", "qos")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(slurm_version, [("slurm-qos", "qos")])
 
         qos = self.slurmrestd.qos()
         self.assertCountEqual(qos, asset)

--- a/slurmweb/tests/slurmrestd/test_slurmrestd_filtered.py
+++ b/slurmweb/tests/slurmrestd/test_slurmrestd_filtered.py
@@ -7,10 +7,7 @@
 import urllib
 
 from slurmweb.slurmrestd import SlurmrestdFiltered
-from ..lib.utils import (
-    all_slurm_versions,
-    SlurmwebAssetUnavailable,
-)
+from ..lib.utils import all_slurm_versions
 from ..lib.slurmrestd import TestSlurmrestdBase, basic_authentifier
 
 
@@ -26,12 +23,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_jobs(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
         jobs = self.slurmrestd.jobs()
         for idx in range(len(jobs)):
             # Check there are less keys for the 1st item in result than in original
@@ -44,13 +38,10 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_job(self, slurm_version):
-        try:
-            [slurmdb_asset, slurm_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-running", "jobs"), ("slurm-job-running", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_asset, slurm_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-running", "jobs"), ("slurm-job-running", "jobs")],
+        )
         job = self.slurmrestd.job(1)
         # Check there are less keys for the item in result than in original asset.
         self.assertLess(len(job.keys()), len(slurm_asset[0].keys()))
@@ -61,12 +52,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_nodes(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-nodes", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-nodes", "nodes")]
+        )
         nodes = self.slurmrestd.nodes()
         for idx in range(len(nodes)):
             # Check there are less keys for the 1st item in result than in original
@@ -79,12 +67,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_node(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-idle", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-idle", "nodes")]
+        )
         node = self.slurmrestd.node("node1")
         # Check there are less keys for the item in result than in original asset.
         self.assertLess(len(node.keys()), len(asset[0].keys()))
@@ -95,12 +80,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_partitions(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-partitions", "partitions")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-partitions", "partitions")]
+        )
         partitions = self.slurmrestd.partitions()
         for idx in range(len(partitions)):
             # Check there are less keys for the 1st item in result than in original
@@ -113,12 +95,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_accounts(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-accounts", "accounts")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-accounts", "accounts")]
+        )
         accounts = self.slurmrestd.accounts()
         for idx in range(len(accounts)):
             # Check there are less keys for the 1st item in result than in original
@@ -131,12 +110,9 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_reservations(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-reservations", "reservations")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-reservations", "reservations")]
+        )
         reservations = self.slurmrestd.reservations()
         for idx in range(len(reservations)):
             # Check there are less keys for the 1st item in result than in original
@@ -149,12 +125,7 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_qos(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-qos", "qos")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(slurm_version, [("slurm-qos", "qos")])
         qos = self.slurmrestd.qos()
         for idx in range(len(qos)):
             # Check there are less keys for the 1st item in result than in original

--- a/slurmweb/tests/slurmrestd/test_slurmrestd_filtered_cached.py
+++ b/slurmweb/tests/slurmrestd/test_slurmrestd_filtered_cached.py
@@ -11,10 +11,7 @@ from slurmweb.slurmrestd import SlurmrestdFilteredCached
 from slurmweb.cache import CachingService
 from slurmweb.errors import SlurmwebCacheError
 
-from ..lib.utils import (
-    all_slurm_versions,
-    SlurmwebAssetUnavailable,
-)
+from ..lib.utils import all_slurm_versions
 from ..lib.slurmrestd import TestSlurmrestdBase, basic_authentifier
 
 
@@ -38,12 +35,9 @@ class TestSlurmrestdFilteredCached(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_not_in_cache(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
         self.slurmrestd.service.get = mock.Mock(return_value=None)
         self.slurmrestd.service.put = mock.Mock()
         jobs = self.slurmrestd.jobs()
@@ -59,12 +53,9 @@ class TestSlurmrestdFilteredCached(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_in_cache(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
         self.slurmrestd.service.get = mock.Mock(return_value=asset)
         self.slurmrestd.service.put = mock.Mock()
         jobs = self.slurmrestd.jobs()
@@ -77,12 +68,9 @@ class TestSlurmrestdFilteredCached(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_cache_get_error(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
         # Check behaviour when SlurmwebCacheError in raised at get()
         self.slurmrestd.service.get = mock.Mock(
             side_effect=SlurmwebCacheError("fake cache error")
@@ -95,12 +83,9 @@ class TestSlurmrestdFilteredCached(TestSlurmrestdBase):
 
     @all_slurm_versions
     def test_cache_put_error(self, slurm_version):
-        try:
-            [asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
         # Check behaviour when SlurmwebCacheError in raised at put()
         self.slurmrestd.service.get = mock.Mock(return_value=None)
         self.slurmrestd.service.put = mock.Mock(

--- a/slurmweb/tests/views/test_agent.py
+++ b/slurmweb/tests/views/test_agent.py
@@ -19,11 +19,7 @@ from slurmweb.slurmrestd.errors import (
 )
 
 from ..lib.agent import TestAgentBase
-from ..lib.utils import (
-    all_slurm_versions,
-    flask_404_description,
-    SlurmwebAssetUnavailable,
-)
+from ..lib.utils import all_slurm_versions, flask_404_description
 
 
 class TestAgentViews(TestAgentBase):
@@ -91,13 +87,11 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_slurmrestd_not_found(self, slurm_version):
-        try:
-            [slurm_not_found_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-not-found", None)],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurm_not_found_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-not-found", None)],
+        )
+
         response = self.client.get(f"/v{get_version()}/jobs")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(
@@ -111,13 +105,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_slurmrestd_authentication_error(self, slurm_version):
-        try:
-            [slurm_not_found_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-jwt-invalid-headers", None)],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurm_not_found_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-jwt-invalid-headers", None)],
+        )
         response = self.client.get(f"/v{get_version()}/jobs")
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
@@ -147,12 +138,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_jobs(self, slurm_version):
-        try:
-            [jobs_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [jobs_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
+
         response = self.client.get(f"/v{get_version()}/jobs")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)
@@ -162,12 +151,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_jobs_node(self, slurm_version):
-        try:
-            [jobs_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-jobs", "jobs")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [jobs_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-jobs", "jobs")]
+        )
 
         def terminated(job):
             for terminated_state in ["COMPLETED", "FAILED", "TIMEOUT"]:
@@ -200,13 +186,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_running(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-running", "jobs"), ("slurm-job-running", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-running", "jobs"), ("slurm-job-running", "jobs")],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -220,13 +203,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_pending(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-pending", "jobs"), ("slurm-job-pending", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-pending", "jobs"), ("slurm-job-pending", "jobs")],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -240,13 +220,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_completed(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-completed", "jobs"), ("slurm-job-completed", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-completed", "jobs"), ("slurm-job-completed", "jobs")],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -260,13 +237,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_failed(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-failed", "jobs"), ("slurm-job-failed", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-failed", "jobs"), ("slurm-job-failed", "jobs")],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -280,13 +254,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_timeout(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-timeout", "jobs"), ("slurm-job-timeout", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-timeout", "jobs"), ("slurm-job-timeout", "jobs")],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -300,13 +271,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_archived(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-archived", "jobs"), ("slurm-job-archived", None)],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-archived", "jobs"), ("slurm-job-archived", None)],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -319,13 +287,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_job_not_found(self, slurm_version):
-        try:
-            [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurmdb-job-unfound", "jobs"), ("slurm-job-unfound", None)],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [slurmdb_job_asset, slurm_job_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurmdb-job-unfound", "jobs"), ("slurm-job-unfound", None)],
+        )
         response = self.client.get(f"/v{get_version()}/job/1")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(
@@ -339,12 +304,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_nodes(self, slurm_version):
-        try:
-            [nodes_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-nodes", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [nodes_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-nodes", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/nodes")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)
@@ -354,12 +316,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_idle(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-idle", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-idle", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -368,13 +327,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_allocated(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-node-allocated", "nodes")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-node-allocated", "nodes")],
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -383,12 +339,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_mixed(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-mixed", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-mixed", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -397,12 +350,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_down(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-down", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-down", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -411,12 +361,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_drained(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-drain", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-drain", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -425,12 +372,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_draining(self, slurm_version):
-        try:
-            [node_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-draining", "nodes")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [node_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-node-draining", "nodes")]
+        )
         response = self.client.get(f"/v{get_version()}/node/cn01")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -439,12 +383,7 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_node_not_found(self, slurm_version):
-        try:
-            self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-node-unfound", None)]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        self.mock_slurmrestd_responses(slurm_version, [("slurm-node-unfound", None)])
         response = self.client.get(f"/v{get_version()}/node/not-found")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(
@@ -458,17 +397,14 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_stats(self, slurm_version):
-        try:
-            [ping_asset, jobs_asset, nodes_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [
-                    ("slurm-ping", "meta"),
-                    ("slurm-jobs", "jobs"),
-                    ("slurm-nodes", "nodes"),
-                ],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [ping_asset, jobs_asset, nodes_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [
+                ("slurm-ping", "meta"),
+                ("slurm-jobs", "jobs"),
+                ("slurm-nodes", "nodes"),
+            ],
+        )
         response = self.client.get(f"/v{get_version()}/stats")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, dict)
@@ -505,13 +441,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_partitions(self, slurm_version):
-        try:
-            [partitions_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-partitions", "partitions")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [partitions_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-partitions", "partitions")],
+        )
         response = self.client.get(f"/v{get_version()}/partitions")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)
@@ -521,12 +454,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_qos(self, slurm_version):
-        try:
-            [qos_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-qos", "qos")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [qos_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-qos", "qos")]
+        )
         response = self.client.get(f"/v{get_version()}/qos")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)
@@ -536,13 +466,10 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_reservations(self, slurm_version):
-        try:
-            [reservations_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-reservations", "reservations")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [reservations_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-reservations", "reservations")],
+        )
         response = self.client.get(f"/v{get_version()}/reservations")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)
@@ -554,12 +481,9 @@ class TestAgentViews(TestAgentBase):
 
     @all_slurm_versions
     def test_request_accounts(self, slurm_version):
-        try:
-            [accounts_asset] = self.mock_slurmrestd_responses(
-                slurm_version, [("slurm-accounts", "accounts")]
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [accounts_asset] = self.mock_slurmrestd_responses(
+            slurm_version, [("slurm-accounts", "accounts")]
+        )
         response = self.client.get(f"/v{get_version()}/accounts")
         self.assertEqual(response.status_code, 200)
         self.assertIsInstance(response.json, list)

--- a/slurmweb/tests/views/test_agent_metrics_collector.py
+++ b/slurmweb/tests/views/test_agent_metrics_collector.py
@@ -20,10 +20,7 @@ from slurmweb.slurmrestd.errors import (
 from slurmweb.errors import SlurmwebCacheError
 
 from ..lib.agent import TestAgentBase
-from ..lib.utils import (
-    all_slurm_versions,
-    SlurmwebAssetUnavailable,
-)
+from ..lib.utils import all_slurm_versions
 
 
 class TestAgentMetricsCollector(TestAgentBase):
@@ -43,13 +40,10 @@ class TestAgentMetricsCollector(TestAgentBase):
 
     @all_slurm_versions
     def test_request_metrics(self, slurm_version):
-        try:
-            [nodes_asset, jobs_asset] = self.mock_slurmrestd_responses(
-                slurm_version,
-                [("slurm-nodes", "nodes"), ("slurm-jobs", "jobs")],
-            )
-        except SlurmwebAssetUnavailable:
-            return
+        [nodes_asset, jobs_asset] = self.mock_slurmrestd_responses(
+            slurm_version,
+            [("slurm-nodes", "nodes"), ("slurm-jobs", "jobs")],
+        )
         response = self.client.get("/metrics")
         self.assertEqual(response.status_code, 200)
         families = list(text_string_to_metric_families(response.text))


### PR DESCRIPTION
The initial plan was to use pytest parametized but it does not support decorators on unittest.TestCase methods. It is mentioned in pytest documentation: https://docs.pytest.org/en/stable/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses

The alternative is to use parameterized external library, just as we do in RacksDB.

fix #540