### PR TITLE
docs: bump API version and support Slurm 25.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Group _drain_ and _draining_ node state filters.
 - conf: Bump `[slurmrestd]` > `version` default value from `0.0.40` to `0.0.41`
   in agent configuration for compatibility with Slurm 25.05.
-- docs: Update configuration reference documentation.
+- docs:
+  - Replace mention of Slurm REST API version v0.0.40 by v0.0.41.
+  - Mention requirement of Slurm >= 24.05 and dropped support of Slurm 23.11.
+  - Update configuration reference documentation.
 
 ### Fixed
 - agent: Fix `AttributeError` with `prometheus_client.registry.Collector` on el8

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -7,8 +7,8 @@ asciidoc:
   attributes:
     source-language: asciidoc@
     table-caption: false
-    version: 4.2.0
-    api_version: 0.0.40
+    version: 5.0.0
+    api_version: 0.0.41
 nav:
 - modules/overview/nav.adoc
 - modules/install/nav.adoc

--- a/docs/modules/install/pages/quickstart.adoc
+++ b/docs/modules/install/pages/quickstart.adoc
@@ -2,9 +2,9 @@
 
 == Requirements
 
-:fn-slurm-version: footnote:slurm-version[Slurm-web {version} actually requires Slurm REST API v{api_version} available in Slurm 23.11 and above. Please refer to xref:overview:architecture.adoc#slurm-versions[Slurm REST API versions section] for more details.]
+:fn-slurm-version: footnote:slurm-version[Slurm-web {version} actually requires Slurm REST API v{api_version} available in Slurm 24.05 and above. Please refer to xref:overview:architecture.adoc#slurm-versions[Slurm REST API versions section] for more details.]
 
-* Cluster with Slurm >= 23.11 {fn-slurm-version} and
+* Cluster with Slurm >= 24.05 {fn-slurm-version} and
 https://slurm.schedmd.com/accounting.html[accounting enabled]
 * Host installed with a supported GNU/Linux distributions among:
 ** CentOS

--- a/docs/modules/overview/pages/architecture.adoc
+++ b/docs/modules/overview/pages/architecture.adoc
@@ -116,8 +116,8 @@ to the *agents* deployed on the clusters.
 == Slurm REST API versions
 
 Slurm-web {version} is officially tested and supported with Slurm REST API
-*v{api_version}*. This version of Slurm REST API is available in Slurm 23.11,
-24.05 and 24.11.
+*v{api_version}*. This version of Slurm REST API is available in Slurm 24.05,
+24.11 and 25.05.
 
 This table represents all Slurm REST API versions supported by the latest Slurm
 releases:
@@ -132,23 +132,23 @@ releases:
 |*Compatible*
 |*Deprecated*
 
-|23.02
-|0.0.39
-|0.0.38
-|0.0.37
-
 |23.11
-|*0.0.40*
+|0.0.40
 |0.0.39
 |0.0.38
 
 |24.05
-|0.0.41
-|*0.0.40*
+|*0.0.41*
+|0.0.40
 |0.0.39
 
 |24.11
 |0.0.42
-|0.0.41
-|*0.0.40*
+|*0.0.41*
+|0.0.40
+
+|25.05
+|0.0.43
+|0.0.42
+|*0.0.41*
 |===


### PR DESCRIPTION
Bump main Slurm-web version and REST API version in docs metadata. Mention support added of Slurm 25.05 and removed for Slurm 23.11. Also mention minimum Slurm version is now 24.05.