### PR TITLE
fix(lib): use SlurmwebAppSeed in wsgi scripts

### DIFF
--- a/lib/wsgi/agent/slurm-web-agent.py
+++ b/lib/wsgi/agent/slurm-web-agent.py
@@ -6,11 +6,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from slurmweb.apps import SlurmwebConfSeed
+from slurmweb.apps import SlurmwebAppSeed
 from slurmweb.apps.agent import SlurmwebAppAgent
 
 application = SlurmwebAppAgent(
-    SlurmwebConfSeed(
+    SlurmwebAppSeed.with_parameters(
         debug=False,
         log_flags=["ALL"],
         log_component=None,

--- a/lib/wsgi/gateway/slurm-web-gateway.py
+++ b/lib/wsgi/gateway/slurm-web-gateway.py
@@ -6,11 +6,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from slurmweb.apps import SlurmwebConfSeed
+from slurmweb.apps import SlurmwebAppSeed
 from slurmweb.apps.gateway import SlurmwebAppGateway
 
 application = SlurmwebAppGateway(
-    SlurmwebConfSeed(
+    SlurmwebAppSeed.with_parameters(
         debug=False,
         log_flags=["ALL"],
         log_component=None,


### PR DESCRIPTION
Replace usage of removed SlurmwebConfSeed class by SlurmwebAppSeed in agent and gateway wsgi scripts.