### PR TITLE
fix(front): properly handle the case where GPU model is unknown in gres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pkgs: Set Python _requests_ external library dependency on agent only.
 - docs: Update configuration reference documentation.
 
+### Fixed
+- front: Handling of GPU declared without model in Slurm configuration (#584).
+  Contribution from @mehalter.
+
 ## [5.0.0] - 2025-05-27
 
 ### Added

--- a/dev/crawler/gateway.py
+++ b/dev/crawler/gateway.py
@@ -329,22 +329,46 @@ class GatewayCrawler(TokenizedComponentCrawler):
         # FIXME: download unknown node
 
     def _crawl_node_gpus_allocated(self, node):
-        self.dump_component_query(
-            f"/api/agents/{self.cluster}/node/{node}",
-            "node-with-gpus-allocated",
+        response = self.get_component_response(
+            f"/api/agents/{self.cluster}/node/{node}"
         )
+        print(response.json())
+        has_model = any(
+            [len(gres.split(":")) > 2 for gres in response.json()["gres"].split(",")]
+        )
+        if has_model:
+            asset = "node-with-gpus-model-allocated"
+        else:
+            asset = "node-with-gpus-allocated"
+        self.dump_component_response(asset, response)
 
     def _crawl_node_gpus_mixed(self, node):
-        self.dump_component_query(
-            f"/api/agents/{self.cluster}/node/{node}",
-            "node-with-gpus-mixed",
+        response = self.get_component_response(
+            f"/api/agents/{self.cluster}/node/{node}"
         )
+        print(response.json())
+        has_model = any(
+            [len(gres.split(":")) > 2 for gres in response.json()["gres"].split(",")]
+        )
+        if has_model:
+            asset = "node-with-gpus-model-mixed"
+        else:
+            asset = "node-with-gpus-mixed"
+        self.dump_component_response(asset, response)
 
     def _crawl_node_gpus_idle(self, node):
-        self.dump_component_query(
-            f"/api/agents/{self.cluster}/node/{node}",
-            "node-with-gpus-idle",
+        response = self.get_component_response(
+            f"/api/agents/{self.cluster}/node/{node}"
         )
+        print(response.json())
+        has_model = any(
+            [len(gres.split(":")) > 2 for gres in response.json()["gres"].split(",")]
+        )
+        if has_model:
+            asset = "node-with-gpus-model-idle"
+        else:
+            asset = "node-with-gpus-idle"
+        self.dump_component_response(asset, response)
 
     def _crawl_node_without_gpu(self, node):
         self.dump_component_query(

--- a/frontend/src/composables/GatewayAPI.ts
+++ b/frontend/src/composables/GatewayAPI.ts
@@ -472,16 +472,19 @@ interface NodeGPU {
   count: number
 }
 
+const gpumatcher = new RegExp('^gpu(?::([^:]*))?(?::([^:]*))$')
+
 export function getNodeGPUFromGres(fullGres: string): NodeGPU[] {
   if (!fullGres.length) return []
   const results: NodeGPU[] = []
   fullGres.split(',').forEach((gres) => {
-    const [type, model, end] = gres.split(':')
-    if (type != 'gpu') return
+    const matched = gpumatcher.exec(gres.replace(/\([^)]*\)$/g, ''))
+    if (matched === null) return
+    const [, model, end] = matched
     let count = -1
     if (end.includes('(')) count = parseInt(end.split('(')[0])
     else count = parseInt(end)
-    results.push({ model: model, count: count })
+    results.push({ model: model || 'unknown', count: count })
   })
   return results
 }

--- a/tests/assets/gateway/node-with-gpus-allocated.json
+++ b/tests/assets/gateway/node-with-gpus-allocated.json
@@ -1,7 +1,7 @@
 {
-  "alloc_cpus": 1,
-  "alloc_idle_cpus": 31,
-  "alloc_memory": 512,
+  "alloc_cpus": 0,
+  "alloc_idle_cpus": 32,
+  "alloc_memory": 0,
   "architecture": "x86_64",
   "boot_time": {
     "infinite": false,
@@ -10,14 +10,14 @@
   },
   "cores": 16,
   "cpus": 32,
-  "gres": "gpu:h100:4",
-  "gres_used": "gpu:h100:4(IDX:0-3)",
+  "gres": "gpu:4",
+  "gres_used": "gpu:4",
   "last_busy": {
     "infinite": false,
-    "number": 1747754445,
+    "number": 1749108801,
     "set": true
   },
-  "name": "gpu2",
+  "name": "gpu1",
   "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
   "partitions": [
     "normal"
@@ -26,7 +26,7 @@
   "reason": "",
   "sockets": 2,
   "state": [
-    "MIXED"
+    "ALLOCATED"
   ],
   "threads": 1
 }

--- a/tests/assets/gateway/node-with-gpus-mixed.json
+++ b/tests/assets/gateway/node-with-gpus-mixed.json
@@ -10,11 +10,11 @@
   },
   "cores": 16,
   "cpus": 32,
-  "gres": "gpu:h100:4",
-  "gres_used": "gpu:h100:1(IDX:0)",
+  "gres": "gpu:4",
+  "gres_used": "gpu:1",
   "last_busy": {
     "infinite": false,
-    "number": 1747754448,
+    "number": 1749072186,
     "set": true
   },
   "name": "gpu1",

--- a/tests/assets/gateway/node-with-gpus-model-allocated.json
+++ b/tests/assets/gateway/node-with-gpus-model-allocated.json
@@ -1,7 +1,7 @@
 {
-  "alloc_cpus": 0,
-  "alloc_idle_cpus": 32,
-  "alloc_memory": 0,
+  "alloc_cpus": 1,
+  "alloc_idle_cpus": 31,
+  "alloc_memory": 512,
   "architecture": "x86_64",
   "boot_time": {
     "infinite": false,
@@ -10,14 +10,14 @@
   },
   "cores": 16,
   "cpus": 32,
-  "gres": "gpu:4",
-  "gres_used": "gpu:0",
+  "gres": "gpu:h100:4",
+  "gres_used": "gpu:h100:4(IDX:0-3)",
   "last_busy": {
     "infinite": false,
-    "number": 1749123356,
+    "number": 1747754445,
     "set": true
   },
-  "name": "gpu1",
+  "name": "gpu2",
   "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
   "partitions": [
     "normal"
@@ -26,8 +26,7 @@
   "reason": "",
   "sockets": 2,
   "state": [
-    "IDLE",
-    "COMPLETING"
+    "MIXED"
   ],
   "threads": 1
 }

--- a/tests/assets/gateway/node-with-gpus-model-idle.json
+++ b/tests/assets/gateway/node-with-gpus-model-idle.json
@@ -10,11 +10,11 @@
   },
   "cores": 16,
   "cpus": 32,
-  "gres": "gpu:4",
-  "gres_used": "gpu:0",
+  "gres": "gpu:h100:4",
+  "gres_used": "gpu:h100:0(IDX:N/A)",
   "last_busy": {
     "infinite": false,
-    "number": 1749123356,
+    "number": 1747776069,
     "set": true
   },
   "name": "gpu1",

--- a/tests/assets/gateway/node-with-gpus-model-mixed.json
+++ b/tests/assets/gateway/node-with-gpus-model-mixed.json
@@ -10,11 +10,11 @@
   },
   "cores": 16,
   "cpus": 32,
-  "gres": "gpu:4",
-  "gres_used": "gpu:0",
+  "gres": "gpu:h100:4",
+  "gres_used": "gpu:h100:1(IDX:0)",
   "last_busy": {
     "infinite": false,
-    "number": 1749123356,
+    "number": 1747754448,
     "set": true
   },
   "name": "gpu1",
@@ -26,8 +26,7 @@
   "reason": "",
   "sockets": 2,
   "state": [
-    "IDLE",
-    "COMPLETING"
+    "ALLOCATED"
   ],
   "threads": 1
 }

--- a/tests/assets/gateway/status.json
+++ b/tests/assets/gateway/status.json
@@ -135,6 +135,18 @@
     "content-type": "application/json",
     "status": 200
   },
+  "node-with-gpus-model-allocated": {
+    "content-type": "application/json",
+    "status": 200
+  },
+  "node-with-gpus-model-idle": {
+    "content-type": "application/json",
+    "status": 200
+  },
+  "node-with-gpus-model-mixed": {
+    "content-type": "application/json",
+    "status": 200
+  },
   "node-without-gpu": {
     "content-type": "application/json",
     "status": 200

--- a/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-allocated.json
+++ b/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-allocated.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 18,
+      "cpu_load": 35,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 3313
+        "number": 2939
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,26 +40,26 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:h100:4",
+      "gres": "gpu:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:h100:4(IDX:0-3)",
+      "gres_used": "gpu:4",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1747754445
+        "number": 1749069208
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "gpu2",
+      "name": "gpu1",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "gpu2",
-      "hostname": "gpu2",
+      "address": "gpu1",
+      "hostname": "gpu1",
       "state": [
-        "MIXED"
+        "ALLOCATED"
       ],
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
@@ -83,15 +83,15 @@
         "number": 0
       },
       "reservation": "",
-      "alloc_memory": 512,
-      "alloc_cpus": 1,
-      "alloc_idle_cpus": 31,
-      "tres_used": "cpu=1,mem=512M",
-      "tres_weighted": 1.0,
+      "alloc_memory": 0,
+      "alloc_cpus": 0,
+      "alloc_idle_cpus": 32,
+      "tres_used": "",
+      "tres_weighted": 0.0,
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1747256521
+        "number": 1749065118
       },
       "sockets": 2,
       "threads": 1,
@@ -104,7 +104,7 @@
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1747754448
+    "number": 1749069211
   },
   "meta": {
     "plugin": {

--- a/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-mixed.json
+++ b/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-mixed.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 18,
+      "cpu_load": 70,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 3313
+        "number": 2978
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,15 +40,15 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:h100:4",
+      "gres": "gpu:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:h100:1(IDX:0)",
+      "gres_used": "gpu:1",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1747754448
+        "number": 1749072186
       },
       "mcs_label": "",
       "specialized_memory": 0,
@@ -91,7 +91,7 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1747256520
+        "number": 1749065118
       },
       "sockets": 2,
       "threads": 1,
@@ -104,7 +104,7 @@
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1747754451
+    "number": 1749072189
   },
   "meta": {
     "plugin": {

--- a/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-allocated.json
+++ b/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-allocated.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 70,
+      "cpu_load": 18,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 2978
+        "number": 3313
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,27 +40,26 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:4",
+      "gres": "gpu:h100:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:0",
+      "gres_used": "gpu:h100:4(IDX:0-3)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1749072191
+        "number": 1747754445
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "gpu1",
+      "name": "gpu2",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "gpu1",
-      "hostname": "gpu1",
+      "address": "gpu2",
+      "hostname": "gpu2",
       "state": [
-        "IDLE",
-        "COMPLETING"
+        "MIXED"
       ],
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
@@ -84,15 +83,15 @@
         "number": 0
       },
       "reservation": "",
-      "alloc_memory": 0,
-      "alloc_cpus": 0,
-      "alloc_idle_cpus": 32,
-      "tres_used": "",
-      "tres_weighted": 0.0,
+      "alloc_memory": 512,
+      "alloc_cpus": 1,
+      "alloc_idle_cpus": 31,
+      "tres_used": "cpu=1,mem=512M",
+      "tres_weighted": 1.0,
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1749065118
+        "number": 1747256521
       },
       "sockets": 2,
       "threads": 1,
@@ -105,7 +104,7 @@
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1749072191
+    "number": 1747754448
   },
   "meta": {
     "plugin": {

--- a/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-idle.json
+++ b/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-idle.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 28,
+      "cpu_load": 18,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 3246
+        "number": 3313
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,31 +40,32 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:h100:2,gpu:h200:4",
+      "gres": "gpu:h100:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:h100:1(IDX:0),gpu:h200:0(IDX:N/A)",
+      "gres_used": "gpu:h100:0(IDX:N/A)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1747755333
+        "number": 1747754453
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "ia1",
+      "name": "gpu1",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "ia1",
-      "hostname": "ia1",
+      "address": "gpu1",
+      "hostname": "gpu1",
       "state": [
-        "ALLOCATED"
+        "IDLE",
+        "COMPLETING"
       ],
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
       "partitions": [
-        "standard"
+        "normal"
       ],
       "port": 6818,
       "real_memory": 524288,
@@ -91,20 +92,20 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1747748740
+        "number": 1747256520
       },
       "sockets": 2,
       "threads": 1,
       "temporary_disk": 0,
       "weight": 1,
       "tres": "cpu=32,mem=512G,billing=32",
-      "version": "25.05.0-0rc1"
+      "version": "24.11.5"
     }
   ],
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1747755335
+    "number": 1747754453
   },
   "meta": {
     "plugin": {
@@ -114,18 +115,18 @@
       "accounting_storage": "accounting_storage/slurmdbd"
     },
     "client": {
-      "source": "admin:6820(fd:9)",
+      "source": "unix:/run/slurmrestd/slurmrestd.socket(fd:20)",
       "user": "root",
       "group": "root"
     },
     "command": [],
     "slurm": {
       "version": {
-        "major": "25",
-        "micro": "0",
-        "minor": "05"
+        "major": "24",
+        "micro": "5",
+        "minor": "11"
       },
-      "release": "25.05.0-0rc1",
+      "release": "24.11.5",
       "cluster": "hpc"
     }
   },

--- a/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-mixed.json
+++ b/tests/assets/slurmrestd/24.11/slurm-node-with-gpus-model-mixed.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 28,
+      "cpu_load": 18,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 3246
+        "number": 3313
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,32 +40,31 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:h100:2,gpu:h200:4",
+      "gres": "gpu:h100:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:h100:0(IDX:N/A),gpu:h200:0(IDX:N/A)",
+      "gres_used": "gpu:h100:1(IDX:0)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1747755336
+        "number": 1747754448
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "ia1",
+      "name": "gpu1",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "ia1",
-      "hostname": "ia1",
+      "address": "gpu1",
+      "hostname": "gpu1",
       "state": [
-        "IDLE",
-        "COMPLETING"
+        "ALLOCATED"
       ],
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
       "partitions": [
-        "standard"
+        "normal"
       ],
       "port": 6818,
       "real_memory": 524288,
@@ -92,20 +91,20 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1747748740
+        "number": 1747256520
       },
       "sockets": 2,
       "threads": 1,
       "temporary_disk": 0,
       "weight": 1,
       "tres": "cpu=32,mem=512G,billing=32",
-      "version": "25.05.0-0rc1"
+      "version": "24.11.5"
     }
   ],
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1747755337
+    "number": 1747754451
   },
   "meta": {
     "plugin": {
@@ -115,18 +114,18 @@
       "accounting_storage": "accounting_storage/slurmdbd"
     },
     "client": {
-      "source": "admin:6820(fd:9)",
+      "source": "unix:/run/slurmrestd/slurmrestd.socket(fd:20)",
       "user": "root",
       "group": "root"
     },
     "command": [],
     "slurm": {
       "version": {
-        "major": "25",
-        "micro": "0",
-        "minor": "05"
+        "major": "24",
+        "micro": "5",
+        "minor": "11"
       },
-      "release": "25.05.0-0rc1",
+      "release": "24.11.5",
       "cluster": "hpc"
     }
   },

--- a/tests/assets/slurmrestd/24.11/status.json
+++ b/tests/assets/slurmrestd/24.11/status.json
@@ -119,6 +119,18 @@
     "content-type": "application/json",
     "status": 200
   },
+  "slurm-node-with-gpus-model-allocated": {
+    "content-type": "application/json",
+    "status": 200
+  },
+  "slurm-node-with-gpus-model-idle": {
+    "content-type": "application/json",
+    "status": 200
+  },
+  "slurm-node-with-gpus-model-mixed": {
+    "content-type": "application/json",
+    "status": 200
+  },
   "slurm-node-without-gpu": {
     "content-type": "application/json",
     "status": 200

--- a/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-allocated.json
+++ b/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-allocated.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 70,
+      "cpu_load": 46,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 2978
+        "number": 3001
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,32 +40,31 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:4",
+      "gres": "gpu:h100:2,gpu:h200:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:0",
+      "gres_used": "gpu:h100:2(IDX:0-1),gpu:h200:4(IDX:2-5)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1749072191
+        "number": 1749072969
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "gpu1",
+      "name": "ia1",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "gpu1",
-      "hostname": "gpu1",
+      "address": "ia1",
+      "hostname": "ia1",
       "state": [
-        "IDLE",
-        "COMPLETING"
+        "ALLOCATED"
       ],
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
       "partitions": [
-        "normal"
+        "standard"
       ],
       "port": 6818,
       "real_memory": 524288,
@@ -92,20 +91,20 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1749065118
+        "number": 1748264252
       },
       "sockets": 2,
       "threads": 1,
       "temporary_disk": 0,
       "weight": 1,
       "tres": "cpu=32,mem=512G,billing=32",
-      "version": "24.11.5"
+      "version": "25.05.0-0rc1"
     }
   ],
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1749072191
+    "number": 1749072970
   },
   "meta": {
     "plugin": {
@@ -115,18 +114,18 @@
       "accounting_storage": "accounting_storage/slurmdbd"
     },
     "client": {
-      "source": "unix:/run/slurmrestd/slurmrestd.socket(fd:20)",
+      "source": "admin:6820(fd:18)",
       "user": "root",
       "group": "root"
     },
     "command": [],
     "slurm": {
       "version": {
-        "major": "24",
-        "micro": "5",
-        "minor": "11"
+        "major": "25",
+        "micro": "0",
+        "minor": "05"
       },
-      "release": "24.11.5",
+      "release": "25.05.0-0rc1",
       "cluster": "hpc"
     }
   },

--- a/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-idle.json
+++ b/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-idle.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 70,
+      "cpu_load": 46,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 2978
+        "number": 3001
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -40,24 +40,24 @@
       "features": [],
       "active_features": [],
       "gpu_spec": "",
-      "gres": "gpu:4",
+      "gres": "gpu:h100:2,gpu:h200:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:0",
+      "gres_used": "gpu:h100:0(IDX:N/A),gpu:h200:0(IDX:N/A)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1749072191
+        "number": 1749072975
       },
       "mcs_label": "",
       "specialized_memory": 0,
-      "name": "gpu1",
+      "name": "ia2",
       "next_state_after_reboot": [
         "INVALID"
       ],
-      "address": "gpu1",
-      "hostname": "gpu1",
+      "address": "ia2",
+      "hostname": "ia2",
       "state": [
         "IDLE",
         "COMPLETING"
@@ -65,7 +65,7 @@
       "operating_system": "Linux 6.1.0-31-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)",
       "owner": "",
       "partitions": [
-        "normal"
+        "standard"
       ],
       "port": 6818,
       "real_memory": 524288,
@@ -92,20 +92,20 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1749065118
+        "number": 1748264254
       },
       "sockets": 2,
       "threads": 1,
       "temporary_disk": 0,
       "weight": 1,
       "tres": "cpu=32,mem=512G,billing=32",
-      "version": "24.11.5"
+      "version": "25.05.0-0rc1"
     }
   ],
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1749072191
+    "number": 1749072976
   },
   "meta": {
     "plugin": {
@@ -115,18 +115,18 @@
       "accounting_storage": "accounting_storage/slurmdbd"
     },
     "client": {
-      "source": "unix:/run/slurmrestd/slurmrestd.socket(fd:20)",
+      "source": "admin:6820(fd:18)",
       "user": "root",
       "group": "root"
     },
     "command": [],
     "slurm": {
       "version": {
-        "major": "24",
-        "micro": "5",
-        "minor": "11"
+        "major": "25",
+        "micro": "0",
+        "minor": "05"
       },
-      "release": "24.11.5",
+      "release": "25.05.0-0rc1",
       "cluster": "hpc"
     }
   },

--- a/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-mixed.json
+++ b/tests/assets/slurmrestd/25.05/slurm-node-with-gpus-model-mixed.json
@@ -13,11 +13,11 @@
       "cores": 16,
       "specialized_cores": 0,
       "cpu_binding": 0,
-      "cpu_load": 34,
+      "cpu_load": 46,
       "free_mem": {
         "set": true,
         "infinite": false,
-        "number": 3231
+        "number": 3001
       },
       "cpus": 32,
       "effective_cpus": 32,
@@ -42,13 +42,13 @@
       "gpu_spec": "",
       "gres": "gpu:h100:2,gpu:h200:4",
       "gres_drained": "N/A",
-      "gres_used": "gpu:h100:2(IDX:0-1),gpu:h200:4(IDX:2-5)",
+      "gres_used": "gpu:h100:1(IDX:0),gpu:h200:0(IDX:N/A)",
       "instance_id": "",
       "instance_type": "",
       "last_busy": {
         "set": true,
         "infinite": false,
-        "number": 1747755330
+        "number": 1749072966
       },
       "mcs_label": "",
       "specialized_memory": 0,
@@ -91,7 +91,7 @@
       "slurmd_start_time": {
         "set": true,
         "infinite": false,
-        "number": 1747748741
+        "number": 1748264254
       },
       "sockets": 2,
       "threads": 1,
@@ -104,7 +104,7 @@
   "last_update": {
     "set": true,
     "infinite": false,
-    "number": 1747755332
+    "number": 1749072973
   },
   "meta": {
     "plugin": {
@@ -114,7 +114,7 @@
       "accounting_storage": "accounting_storage/slurmdbd"
     },
     "client": {
-      "source": "admin:6820(fd:9)",
+      "source": "admin:6820(fd:18)",
       "user": "root",
       "group": "root"
     },

--- a/tests/assets/slurmrestd/25.05/status.json
+++ b/tests/assets/slurmrestd/25.05/status.json
@@ -123,15 +123,15 @@
     "content-type": "application/json",
     "status": 200
   },
-  "slurm-node-with-gpus-allocated": {
+  "slurm-node-with-gpus-model-allocated": {
     "content-type": "application/json",
     "status": 200
   },
-  "slurm-node-with-gpus-idle": {
+  "slurm-node-with-gpus-model-idle": {
     "content-type": "application/json",
     "status": 200
   },
-  "slurm-node-with-gpus-mixed": {
+  "slurm-node-with-gpus-model-mixed": {
     "content-type": "application/json",
     "status": 200
   },


### PR DESCRIPTION
This moves to a regular expression matcher rather than just splitting on `:` and assuming the number of fields. This will pull out a model if it exists and a count (assumed to exist because it's a hard requirement). The regular expression utilizes lookback assertions on the `:` character to make sure the capture groups do not include the `:` character. It simply extracts the model (if exists) and count.

I have tested this locally with an active Slurm deployment that has both GPUs with models known and models unknown and they render correctly. In the case of unknown models, we simply say "unknown".

EDIT: The new commit makes sure to remove the unnecessary `IDX` information before parsing the GPU information from the string.


Closes #584 