### PR TITLE
fix: unable to parse GPUs from GRES if there is a comma in brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Handling of GPU declared without model in Slurm configuration (#584).
     Contribution from @mehalter.
   - Regression on handling of denied clusters in cluster list.
+  - Parsing of GRES GPUs when comma is present between brakets with indexes or
+    sockets. Contribution from @astappiev.
 
 ## [5.0.0] - 2025-05-27
 

--- a/frontend/src/composables/GatewayAPI.ts
+++ b/frontend/src/composables/GatewayAPI.ts
@@ -472,12 +472,13 @@ interface NodeGPU {
   count: number
 }
 
+const gresMatcher = new RegExp(',(?![^()]*\\))')
 const gpumatcher = new RegExp('^gpu(?::([^:]*))?(?::([^:]*))$')
 
 export function getNodeGPUFromGres(fullGres: string): NodeGPU[] {
   if (!fullGres.length) return []
   const results: NodeGPU[] = []
-  fullGres.split(',').forEach((gres) => {
+  fullGres.split(gresMatcher).forEach((gres) => {
     const matched = gpumatcher.exec(gres.replace(/\([^)]*\)$/g, ''))
     if (matched === null) return
     const [, model, end] = matched

--- a/frontend/tests/composables/GatewayAPI.spec.ts
+++ b/frontend/tests/composables/GatewayAPI.spec.ts
@@ -599,6 +599,9 @@ describe('getNodeGPUFromGres', () => {
   test('with model and index', () => {
     expect(getNodeGPUFromGres('gpu:h100:2(IDX:0-1)')).toStrictEqual([{ model: 'h100', count: 2 }])
   })
+  test('with model and socket', () => {
+    expect(getNodeGPUFromGres('gpu:h100:8(S:1,3,5,7)')).toStrictEqual([{ model: 'h100', count: 8 }])
+  })
   test('multiple types', () => {
     expect(getNodeGPUFromGres('gpu:1,gpu:h100:2,gpu:h200:4')).toStrictEqual([
       { model: 'unknown', count: 1 },
@@ -788,6 +791,9 @@ describe('getNodeGPU', () => {
   })
   test('with model and index', () => {
     expect(getNodeGPU('gpu:h100:2(IDX:0-1)')).toStrictEqual(['2 x h100'])
+  })
+  test('with model and multiple indexes', () => {
+    expect(getNodeGPU('gpu:h100:5(IDX:0-2,4-5)')).toStrictEqual(['5 x h100'])
   })
   test('multiple types', () => {
     expect(getNodeGPU('gpu:1,gpu:h100:2,gpu:h200:4')).toStrictEqual([


### PR DESCRIPTION
We met an error where one of our nodes has no GPUs in Slurm-Web.

![image](https://github.com/user-attachments/assets/def0fe8f-3faf-4bfe-8b8d-4aa7343e5370)

After the investigation, I was able to localize the error and fix it. It was caused by the weird Socket IDs in the DGX A100 server.

![image](https://github.com/user-attachments/assets/f2ea1b47-17a9-4eb2-859e-8fb944d3ec5d)

The previous version of the code was splitting the gres string by all comma characters; the suggested version splits only by commas, if they are not enclosed in brackets.
