### PR TITLE
docs: fix rendering of example list params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Parsing of GRES GPUs when comma is present between brackets with indexes or
     sockets. Contribution from @astappiev.
   - Update dependencies to fix CVE-2025-5889 (brace-expansion).
+- docs: Fix rendering of example list values in generated configuration
+  reference documentation (#599).
 
 ## [5.0.0] - 2025-05-27
 

--- a/docs/modules/conf/partials/conf-gateway.adoc
+++ b/docs/modules/conf/partials/conf-gateway.adoc
@@ -254,7 +254,13 @@ representations.
 |List of Slurm-web agents URL
 
 
-*Example:* `['https://cluster1/agent', 'https://cluster2/agent']`
+*Example:*
+
+
+* `https://cluster1/agent`
+
+* `https://cluster2/agent`
+
 
 
 _No default value_
@@ -565,7 +571,13 @@ defined, all users in LDAP directory are authorized to sign in.
 
 
 
-*Example:* `['admins', 'biology']`
+*Example:*
+
+
+* `admins`
+
+* `biology`
+
 
 
 _No default value_

--- a/docs/utils/conf-ref.adoc.j2
+++ b/docs/utils/conf-ref.adoc.j2
@@ -28,7 +28,15 @@
 WARNING: This parameter is *deprecated* in favor of `[{{ parameter.deprecated.section }}]` > `{{ parameter.deprecated.parameter }}`.
 {% endif %}
 {% if parameter.example != None %}
+{%- if parameter.example.__class__.__name__ == 'list' %}
+*Example:*
+
+{% for example in parameter.example %}
+* `{{ example }}`
+{% endfor %}
+{%- else %}
 *Example:* `{{ parameter.example }}`
+{%- endif %}
 {% endif %}
 {% if parameter.choices %}
 *Choices:*


### PR DESCRIPTION
Fix rendering of example list values in generated configuration reference documentation.

fix #599