### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/slurmweb/apps/__init__.py
+++ b/slurmweb/apps/__init__.py
@@ -30,7 +30,7 @@ def load_ldap_password_from_file(bind_password_file: Optional[Path]) -> Optional
     if bind_password_file is None:
         return None
 
-    logger.debug(f"Loading LDAP bind password from path {bind_password_file}")
+    logger.debug("Loading LDAP bind password from the specified file")
 
     if not bind_password_file.is_file():
         raise SlurmwebConfigurationError(


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/Slurm-web/security/code-scanning/1](https://github.com/rackslab/Slurm-web/security/code-scanning/1)

To fix the issue, the logging statement should be modified to avoid including sensitive information such as the file path. Instead, a generic message can be logged to indicate the operation without revealing specifics. This ensures that no sensitive data is exposed in the logs.

The fix involves:
1. Replacing the logging statement on line 33 with a generic message that does not include the file path.
2. Ensuring that the functionality of the code remains unchanged while improving security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
