### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+permissions:
+  contents: read
 
 jobs:
   python_tests:


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/Slurm-web/security/code-scanning/6](https://github.com/rackslab/Slurm-web/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function. Since the workflow primarily runs tests and does not interact with repository contents, the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within individual jobs if different permissions are required for each job. In this case, adding it at the root level is appropriate for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
