### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/Slurm-web/security/code-scanning/3](https://github.com/rackslab/Slurm-web/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily uses actions for checking out code and running pre-commit checks, it only requires read access to repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`pre-commit`) in this workflow.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow.
2. Setting `contents: read` to limit the permissions of the `GITHUB_TOKEN` to read-only access for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
