### PR TITLE
chore(ci): split frontend/backend tests workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,38 @@
+---
+name: Frontend Tests
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - 'tests/assets/gateway/**'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - 'tests/assets/gateway/**'
+      - '.github/workflows/frontend-ci.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  vuejs_tests:
+    name: Vue.js unit tests
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install npm packages
+        run: cd frontend && npm ci
+      - name: Run tests
+        run: cd frontend && npm run test:unit

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,13 +1,26 @@
 ---
-name: Automated Tests
+name: Backend Tests
 on:
   push:
     branches:
       - main
+    paths:
+      - 'slurmweb/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - '.github/workflows/python-ci.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'slurmweb/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - '.github/workflows/python-ci.yml'
   workflow_dispatch: {}
+
 permissions:
   contents: read
 
@@ -194,19 +207,3 @@ jobs:
 
       - name: Run tests
         run: pytest
-
-  vuejs_tests:
-    name: Vue.js unit tests
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install npm packages
-        run: cd frontend && npm ci
-      - name: Run tests
-        run: cd frontend && npm run test:unit


### PR DESCRIPTION
This way, it becomes possible to run only relevant tests based on modified files, and skip selective tests when files are not changed.