### PR TITLE
fix(front): fix centering of node tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `cache-miss-total` keys are missing in Redis cache (#622).
 - front:
   - Round allocated resources percentages with one decimal in node details page.
+  - Fix centering of node tooltip over the racks graphical representation.
   - Update dependencies to fix CVE-2025-7783 (form-data), CVE-2025-58751,
     CVE-2025-58752 and CVE-2025-62522 (vite), CVE-2025-58754 (axios).
   - Handling of cache hit rate calculation when total number of requests in

--- a/frontend/src/components/resources/ResourcesCanvas.vue
+++ b/frontend/src/components/resources/ResourcesCanvas.vue
@@ -225,8 +225,10 @@ function setMouseEventHandler() {
           }
           // Position nodeTooltip
           if (nodeTooltip.value && container.value) {
+            // The tooltip has a width of w-40, ie. 160px. Shift its left side
+            // to center it on the node, and right-shift it by 1px.
             nodeTooltip.value.style.left =
-              (nodePath.x + (nodePath.width - 176) / 2).toString() + 'px'
+              (nodePath.x + (nodePath.width - 160) / 2 - 1).toString() + 'px'
             nodeTooltip.value.style.bottom =
               (container.value.offsetHeight - nodePath.y + 10).toString() + 'px'
           }


### PR DESCRIPTION
Fix centering of node tooltip over the racks graphical representation, it was slightly shifted on the left for some reason.