### PR TITLE
fix(gateway): use agent provided version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+#### Fixed
+- gateway: Use agent provided version instead of agent minimal version from
+  settings to reverse proxy the requests (#656).
+
 ## [5.2.0] - 2025-11-03
 
 ### Added

--- a/slurmweb/views/gateway.py
+++ b/slurmweb/views/gateway.py
@@ -203,7 +203,7 @@ def request_agent(
         if with_version:
             url = (
                 f"{current_app.agents[cluster].url}/"
-                f"v{current_app.settings.agents.version}/{query}"
+                f"v{current_app.agents[cluster].version}/{query}"
             )
         else:
             url = f"{current_app.agents[cluster].url}/{query}"


### PR DESCRIPTION
Use agent provided version instead of agent minimal version from settings to reverse proxy the requests.

fix #656