### PR TITLE
Fix ClusterShell NodeSet import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- agent: Import of ClusterShell NodeSet class (#682). Contribution from
+  @faganihajizada.
+
 ## [6.0.0] - 2025-11-28
 
 ### Added

--- a/slurmweb/slurmrestd/__init__.py
+++ b/slurmweb/slurmrestd/__init__.py
@@ -9,7 +9,7 @@ import urllib
 import logging
 
 import requests
-import ClusterShell
+from ClusterShell.NodeSet import NodeSet
 
 from .unix import SlurmrestdUnixAdapter
 from .auth import SlurmrestdAuthentifier
@@ -222,7 +222,7 @@ class Slurmrestd:
             """Return True if job is allocated this node."""
             if job["nodes"] == "":
                 return False
-            return node in ClusterShell.NodeSet.NodeSet(job["nodes"])
+            return node in NodeSet(job["nodes"])
 
         def terminated(job):
             """Return True if job is terminated."""

--- a/slurmweb/tests/slurmrestd/test_slurmrestd.py
+++ b/slurmweb/tests/slurmrestd/test_slurmrestd.py
@@ -9,7 +9,7 @@ import random
 import urllib
 
 import requests
-import ClusterShell
+from ClusterShell.NodeSet import NodeSet
 
 from slurmweb.slurmrestd import Slurmrestd
 from slurmweb.slurmrestd.errors import (
@@ -177,7 +177,7 @@ class TestSlurmrestd(TestSlurmrestdBase):
             return False
 
         # Select random busy node on cluster
-        busy_nodes = ClusterShell.NodeSet.NodeSet()
+        busy_nodes = NodeSet()
         for job in asset:
             if not terminated(job):
                 busy_nodes.update(job["nodes"])
@@ -195,7 +195,7 @@ class TestSlurmrestd(TestSlurmrestdBase):
             self.assertNotIn(job["job_state"], ["COMPLETED", "FAILED", "TIMEOUT"])
             self.assertIn(
                 random_busy_node,
-                ClusterShell.NodeSet.NodeSet(job["nodes"]),
+                NodeSet(job["nodes"]),
             )
 
         # Test get jobs on nonexistent node.

--- a/slurmweb/tests/views/test_agent.py
+++ b/slurmweb/tests/views/test_agent.py
@@ -8,7 +8,7 @@
 from unittest import mock
 import random
 
-import ClusterShell
+from ClusterShell.NodeSet import NodeSet
 
 from racksdb.version import get_version as racksdb_get_version
 
@@ -191,7 +191,7 @@ class TestAgentViews(TestAgentBase):
             return False
 
         # Select random busy node on cluster
-        busy_nodes = ClusterShell.NodeSet.NodeSet()
+        busy_nodes = NodeSet()
         for job in jobs_asset:
             if not terminated(job):
                 busy_nodes.update(job["nodes"])
@@ -210,7 +210,7 @@ class TestAgentViews(TestAgentBase):
             self.assertNotIn(job["job_state"], ["COMPLETED", "FAILED", "TIMEOUT"])
             self.assertIn(
                 random_busy_node,
-                ClusterShell.NodeSet.NodeSet(job["nodes"]),
+                NodeSet(job["nodes"]),
             )
 
     @all_slurm_api_versions


### PR DESCRIPTION
# Summary

The current code uses import ClusterShell followed by ClusterShell.NodeSet.NodeSet(), which causes an AttributeError because the ClusterShell module doesn't expose NodeSet as a direct attribute when imported this way.
This bug prevents users from viewing jobs filtered by a specific node in the web UI.

examples: https://github.com/cea-hpc/clustershell/blob/master/doc/examples/check_nodes.py

# Solution
Changed to import NodeSet directly:

```
from ClusterShell.NodeSet import NodeSet
```

This fix has been applied to:
- Main code (slurmweb/slurmrestd/__init__.py)
- Test files (slurmweb/tests/slurmrestd/test_slurmrestd.py, slurmweb/tests/views/test_agent.py)

# Test

- The import works correctly with ClusterShell
- Only NodeSet functionality is used in the codebase
- No other ClusterShell modules are required