### PR TITLE
Make RacksDB dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configuration guides to setup production HTTP server (apache2, nginx and
     caddy) on SLES.
 
+### Changed
+- agent: Make RacksDB library optional with lazy loading only when enabled in
+  configuration (#683). Contribution from @faganihajizada.
+
 ### Fixed
 - agent: Import of ClusterShell NodeSet class (#682). Contribution from
   @faganihajizada.

--- a/slurmweb/apps/agent.py
+++ b/slurmweb/apps/agent.py
@@ -9,8 +9,6 @@ import urllib
 import logging
 
 from rfl.web.tokens import RFLTokenizedRBACWebApp
-from racksdb.errors import RacksDBSchemaError, RacksDBFormatError
-from racksdb.web.app import RacksDBWebBlueprint
 
 try:
     from werkzeug.middleware import dispatcher
@@ -65,6 +63,11 @@ class SlurmwebAppAgent(SlurmwebWebApp, RFLTokenizedRBACWebApp):
         # If enabled, load RacksDB blueprint and fail with error if unable to load
         # schema or database.
         if self.settings.racksdb.enabled:
+            # Lazy load RacksDB module to avoid failing on missing optional external
+            # dependency when feature is actually disabled.
+            from racksdb.errors import RacksDBSchemaError, RacksDBFormatError
+            from racksdb.web.app import RacksDBWebBlueprint
+
             try:
                 self.register_blueprint(
                     RacksDBWebBlueprint(

--- a/slurmweb/tests/apps/test_agent.py
+++ b/slurmweb/tests/apps/test_agent.py
@@ -5,11 +5,12 @@
 # SPDX-License-Identifier: MIT
 
 import sys
+import unittest
 from unittest import mock
 
 from slurmweb.errors import SlurmwebConfigurationError
 
-from ..lib.agent import TestAgentBase
+from ..lib.agent import TestAgentBase, is_racksdb_available
 
 
 class TestAgentApp(TestAgentBase):
@@ -22,6 +23,7 @@ class TestAgentApp(TestAgentBase):
             with self.assertNoLogs("slurmweb", level="ERROR"):
                 self.setup_client()
 
+    @unittest.skipIf(not is_racksdb_available(), "RacksDB not installed")
     def test_app_racksdb_format_error(self):
         with self.assertLogs("slurmweb", level="ERROR") as cm:
             self.setup_client(racksdb_format_error=True)
@@ -33,6 +35,7 @@ class TestAgentApp(TestAgentBase):
             ],
         )
 
+    @unittest.skipIf(not is_racksdb_available(), "RacksDB not installed")
     def test_app_racksdb_schema_error(self):
         with self.assertLogs("slurmweb", level="ERROR") as cm:
             self.setup_client(racksdb_schema_error=True)

--- a/slurmweb/tests/lib/gateway.py
+++ b/slurmweb/tests/lib/gateway.py
@@ -14,13 +14,15 @@ import werkzeug
 import jinja2
 
 from rfl.authentication.user import AuthenticatedUser, AnonymousUser
-from racksdb.version import get_version as racksdb_get_version
+
 from slurmweb.version import get_version
 from slurmweb.apps import SlurmwebAppSeed
 from slurmweb.apps.gateway import SlurmwebAppGateway
 from slurmweb.apps.gateway import SlurmwebAgent, SlurmwebAgentRacksDBSettings
+from slurmweb.views.agent import racksdb_get_version
 
 from .utils import SlurmwebCustomTestResponse
+
 
 CONF_TPL = """
 [agents]

--- a/slurmweb/tests/views/test_agent.py
+++ b/slurmweb/tests/views/test_agent.py
@@ -10,14 +10,13 @@ import random
 
 from ClusterShell.NodeSet import NodeSet
 
-from racksdb.version import get_version as racksdb_get_version
-
 from slurmweb.version import get_version
 from slurmweb.slurmrestd.errors import (
     SlurmrestConnectionError,
     SlurmrestdInvalidResponseError,
 )
 from slurmweb.cache import CachingService
+from slurmweb.views.agent import racksdb_get_version
 
 from ..lib.agent import TestAgentBase
 from ..lib.utils import all_slurm_api_versions, flask_404_description

--- a/slurmweb/tests/views/test_agent_racksdb.py
+++ b/slurmweb/tests/views/test_agent_racksdb.py
@@ -4,11 +4,13 @@
 #
 # SPDX-License-Identifier: MIT
 
+import unittest
 
-from ..lib.agent import TestAgentBase
+from ..lib.agent import TestAgentBase, is_racksdb_available
 from ..lib.utils import flask_404_description
 
 
+@unittest.skipIf(not is_racksdb_available(), "RacksDB not installed")
 class TestAgentRacksDBEnabledRequest(TestAgentBase):
     def setUp(self):
         self.setup_client()
@@ -23,6 +25,7 @@ class TestAgentRacksDBEnabledRequest(TestAgentBase):
         )
 
 
+@unittest.skipIf(not is_racksdb_available(), "RacksDB not installed")
 class TestAgentRacksDBUnabledRequest(TestAgentBase):
     def setUp(self):
         self.setup_client(racksdb_format_error=True)

--- a/slurmweb/views/agent.py
+++ b/slurmweb/views/agent.py
@@ -9,7 +9,6 @@ import logging
 
 from flask import Response, current_app, jsonify, abort, request
 from rfl.web.tokens import rbac_action, check_jwt
-from racksdb.version import get_version as racksdb_get_version
 
 from ..version import get_version
 from ..errors import SlurmwebCacheError, SlurmwebMetricsDBError
@@ -24,6 +23,16 @@ from ..slurmrestd.errors import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def racksdb_get_version():
+    """Get RacksDB version if available, or return 'N/A' if not installed."""
+    try:
+        from racksdb.version import get_version
+
+        return get_version()
+    except ModuleNotFoundError:
+        return "N/A (not installed)"
 
 
 def version():


### PR DESCRIPTION
## Summary

RacksDB is marked as an optional dependency in `pyproject.toml` under the `[agent]` extra, but the code has unconditional imports at the module level:

```python
from racksdb.errors import RacksDBSchemaError, RacksDBFormatError
from racksdb.web.app import RacksDBWebBlueprint
```

This causes `ModuleNotFoundError` when running the agent without RacksDB installed.

## Solution

This PR makes RacksDB imports conditional using the existing `werkzeug` optional import pattern found in the codebase (`slurmweb/apps/agent.py`):

- Module-level try/except: Wrap RacksDB imports in `try/except ModuleNotFoundError` block
- Stub exception classes: Provide stub classes to satisfy Python's exception handling requirements
- Configuration validation: Fail early with clear error message if RacksDB is enabled but not installed
- Graceful fallbacks: Version display shows "N/A (not installed)" when RacksDB is unavailable

## Testing

- All tests pass with RacksDB mocked as available
- Agent starts successfully without RacksDB when `racksdb.enabled=false`
- Clear error message when `racksdb.enabled=true` but RacksDB not installed
- Deployed and tested
