### PR TITLE
Update policy.ini: file is not called policy.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CVE-2026-27903, CVE-2026-27904, CVE-2026-26996 (minimatch), CVE-2026-32141,
   CVE-2026-33228 (flatted), CVE-2026-33671, CVE-2026-33672 (picomatch),
   CVE-2026-39363 (vite) and GHSA-r4q5-vmmm-2653 (follow-redirects).
+- conf: Fix extension of filename mentioned in policy configuration file
+  comment. Contribution from @fschlich.
 - docs: Fix user/group name in agent uWSGI service diff context.
 
 ### Removed

--- a/conf/vendor/policy.ini
+++ b/conf/vendor/policy.ini
@@ -1,5 +1,5 @@
 # Slurm-web default vendor RBAC policy. DO NOT MODIFY THIS FILE! Create a file
-# /etc/slurm-web/policy.conf with your custom rules and Slurm-web will ignore
+# /etc/slurm-web/policy.ini with your custom rules and Slurm-web will ignore
 # this file. Your modifications in this file will be overwritten and lost on
 # software upgrade.
 


### PR DESCRIPTION
I usually trust "code" comments more than docs published on the web, but in this case "code" needs fixing