### PR TITLE
Drop testing dependency on parameterized

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -103,7 +103,6 @@ jobs:
             python3-flask \
             python3-importlib-metadata \
             python3-markdown \
-            python3-parameterized \
             python3-pip \
             python3-prometheus_client \
             python3-pytest \
@@ -184,7 +183,6 @@ jobs:
             python3-clustershell \
             python3-flask \
             python3-markdown \
-            python3-parameterized \
             python3-pip \
             python3-prometheus-client \
             python3-pytest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - front: Update bundled dependencies to fix CVE-2026-46625 (js-cookie).
 
 ### Removed
-- pkgs: Testing dependency on _parameterized_ external library.
+- pkgs: Drop testing dependency on _parameterized_ external library.
 
 ## [6.1.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in RFL >= 1.8.0.
   - Add gateway dependency on `RFL.authentication[ldap]` extra package provided
     in RFL >= 1.8.0.
+  - Add dependency on `RFL.build` >= 1.8.0 for testing.
 - docs:
   - Mention official support of Ubuntu 26.04 LTS _« Resolute Raccoon »_.
   - Add upgrade guide for migration from v6 to v7.
@@ -29,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - front: Update bundled dependencies to fix CVE-2026-46625 (js-cookie).
+
+### Removed
+- pkgs: Testing dependency on _parameterized_ external library.
 
 ## [6.1.0] - 2026-05-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ gateway = [
 tests = [
     "coverage",
     "Jinja2",
-    "parameterized",
+    "RFL.build >= 1.8.0",
     "pytest",
     "pytest-cov",
 ]

--- a/slurmweb/tests/lib/utils.py
+++ b/slurmweb/tests/lib/utils.py
@@ -13,7 +13,7 @@ import copy
 import requests
 import flask
 import aiohttp
-import parameterized
+from rfl.build.testing.params import expand
 
 ASSETS = Path(__file__).parent.resolve() / ".." / ".." / ".." / "tests" / "assets"
 
@@ -43,9 +43,7 @@ def load_json_asset(path: Path):
         return json.load(f)
 
 
-all_slurm_api_versions = parameterized.parameterized.expand(
-    slurm_api_version_combinations()
-)
+all_slurm_api_versions = expand(slurm_api_version_combinations())
 
 
 def flask_version():


### PR DESCRIPTION
Adopt rfl.build.testing.params as a in-house alternative.