### PR TITLE
docs: fix successful spelling in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - front: Update bundled dependencies to fix CVE-2026-46625 (js-cookie).
+- docs: typo in configuration guide. Contribution from @yosinn1-blip.
 
 ### Removed
 - pkgs: Drop testing dependency on _parameterized_ external library.

--- a/docs/modules/conf/partials/agent-restart.adoc
+++ b/docs/modules/conf/partials/agent-restart.adoc
@@ -1,4 +1,4 @@
-Upon succesful test, restart agent service to apply changes:
+Upon successful test, restart agent service to apply changes:
 
 [tabs]
 ======


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/modules/conf/partials/agent-restart.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
