### PR TITLE
fix(agent): coherent job detail for array, requeued, and reused job-ids

### DIFF
--- a/slurmweb/slurmrestd/__init__.py
+++ b/slurmweb/slurmrestd/__init__.py
@@ -624,18 +624,81 @@ class SlurmrestdFiltered(SlurmrestdAdapter):
             super()._acctjob(job_id, **kwargs), self.filters.acctjob
         )
 
+    @staticmethod
+    def _job_start(record: t.Dict) -> int:
+        """Best-effort start timestamp, across slurmctld and slurmdbd schemas."""
+        for path in (("start_time",), ("time", "start")):
+            value = record
+            for key in path:
+                value = value.get(key) if isinstance(value, dict) else None
+            if isinstance(value, dict):
+                value = value.get("number")
+            if isinstance(value, (int, float)):
+                return int(value)
+        return 0
+
+    @staticmethod
+    def _array_task(record: t.Dict):
+        """Array task id (or None for non-array jobs), across both schemas."""
+        task = record.get("array_task_id")  # slurmctld flat schema
+        if task is None:
+            array = record.get("array")  # slurmdbd nested schema
+            task = array.get("task_id") if isinstance(array, dict) else None
+        if isinstance(task, dict):
+            return task.get("number") if task.get("set", True) else None
+        return task
+
     def job(self, job_id: int):
+        # A single job-id can map to MANY records: array tasks (each with a
+        # distinct internal job-id), requeue/preempt lifecycle duplicates, and
+        # reused job-ids. Taking [0] of each list and blindly merging them mixes
+        # unrelated records into one incoherent job (e.g. the live state of the
+        # running task merged with the accounting of an unrelated terminated
+        # job). Select coherent records instead: the live record is
+        # authoritative for current state; the accounting record is the one
+        # describing the SAME task/run.
         try:
-            result = self._acctjob(job_id)
-        except IndexError:
-            raise SlurmrestdNotFoundError(f"Job {job_id} not found")
-        # try to enrich result with additional fields from slurmctld
+            acct_records = self._request("slurmdb", f"job/{job_id}", "jobs")
+        except (SlurmrestdInternalError, SlurmrestdNotFoundError):
+            # Accounting is optional: a cluster may run without slurmdbd (the
+            # slurmdb query then errors or 404s). Job detail is served from
+            # slurmctld alone in that case.
+            acct_records = []
         try:
-            result.update(self._ctldjob(job_id, ignore_notfound=True))
+            ctld_records = self._request(
+                "slurm", f"job/{job_id}", "jobs", ignore_notfound=True
+            )
         except SlurmrestdInternalError as err:
             if err.error != 2017:
                 raise err
-            # pass the error, the job is just not available in ctld queue
+            # job is just not available in the ctld queue anymore
+            ctld_records = []
+        if not acct_records and not ctld_records:
+            raise SlurmrestdNotFoundError(f"Job {job_id} not found")
+
+        # Live record (authoritative for current state): the most recently
+        # started still-queued task for this id.
+        live = max(ctld_records, key=self._job_start) if ctld_records else None
+        if live is not None:
+            live_job_id = live.get("job_id")
+            live_task = self._array_task(live)
+            matching = [
+                record
+                for record in acct_records
+                if record.get("job_id") == live_job_id
+                and self._array_task(record) == live_task
+            ] or acct_records
+            acct = max(matching, key=self._job_start) if matching else None
+        else:
+            # No live record: most recent accounting record (disambiguates
+            # reused job-ids and requeue duplicates).
+            acct = max(acct_records, key=self._job_start)
+
+        result = {}
+        if acct is not None:
+            result = SlurmrestdFiltered.filter_fields(acct, self.filters.acctjob)
+        if live is not None:
+            result.update(SlurmrestdFiltered.filter_fields(live, self.filters.ctldjob))
         return result
 
     def nodes(self):

--- a/slurmweb/tests/slurmrestd/test_slurmrestd_filtered.py
+++ b/slurmweb/tests/slurmrestd/test_slurmrestd_filtered.py
@@ -5,9 +5,11 @@
 # SPDX-License-Identifier: MIT
 
 import urllib
+from unittest import mock
 
 from slurmweb.slurmrestd import SlurmrestdFiltered
 from slurmweb.slurmrestd import TERMINAL_JOB_STATES
+from slurmweb.slurmrestd.errors import SlurmrestdNotFoundError
 from ..lib.utils import SlurmwebAssetUnavailable, all_slurm_api_versions
 from ..lib.slurmrestd import (
     TestSlurmrestdBase,
@@ -60,6 +62,119 @@ class TestSlurmrestdFiltered(TestSlurmrestdBase):
         # Check arbitrary key has been filtered out.
         self.assertIn("array_job_id", slurm_asset[0])
         self.assertNotIn("array_job_id", job)
+
+    def test_job_multi_record_coherent(self):
+        """A job-id mapping to many slurmdbd records (an unrelated terminated
+        job that reused the id, plus an array task's preempted and current
+        runs) must resolve to the live task's own accounting -- not the
+        reused-id job, and not merely the newest record overall. _request is
+        mocked directly (keyed on the component) to avoid version-specific
+        fixtures."""
+        acct = [
+            {
+                "job_id": 1,
+                "array": {"task_id": {"set": False, "number": 0}},
+                "time": {"start": {"number": 5000}},
+                "state": {"current": ["FAILED"]},
+            },
+            {
+                "job_id": 1,
+                "array": {
+                    "job_id": {"number": 1},
+                    "task_id": {"set": True, "number": 5},
+                },
+                "time": {"start": {"number": 2000}},
+                "state": {"current": ["PREEMPTED"]},
+            },
+            {
+                "job_id": 1,
+                "array": {
+                    "job_id": {"number": 1},
+                    "task_id": {"set": True, "number": 5},
+                },
+                "time": {"start": {"number": 3000}},
+                "state": {"current": ["RUNNING"]},
+            },
+        ]
+        ctld = [
+            {
+                "job_id": 1,
+                "array_job_id": {"number": 1},
+                "array_task_id": {"set": True, "number": 5},
+                "start_time": {"number": 3000},
+                "job_state": ["RUNNING"],
+            }
+        ]
+        with mock.patch.object(
+            self.slurmrestd,
+            "_request",
+            side_effect=lambda component, *a, **k: {"slurmdb": acct, "slurm": ctld}[
+                component
+            ],
+        ):
+            job = self.slurmrestd.job(1)
+        # The accounting half is the current run of the live task (start 3000),
+        # not the reused-id job (start 5000) nor the preempted run (start 2000).
+        self.assertEqual(job["time"]["start"]["number"], 3000)
+
+    def test_job_aged_out_of_slurmctld(self):
+        """When the job is gone from slurmctld (empty list), job() returns the
+        most recent accounting record without raising IndexError."""
+        acct = [
+            {
+                "job_id": 2,
+                "array": {"task_id": {"set": False, "number": 0}},
+                "time": {"start": {"number": 1000}},
+                "state": {"current": ["FAILED"]},
+            },
+            {
+                "job_id": 2,
+                "array": {"task_id": {"set": False, "number": 0}},
+                "time": {"start": {"number": 2000}},
+                "state": {"current": ["COMPLETED"]},
+            },
+        ]
+        with mock.patch.object(
+            self.slurmrestd,
+            "_request",
+            side_effect=lambda component, *a, **k: {"slurmdb": acct, "slurm": []}[
+                component
+            ],
+        ):
+            job = self.slurmrestd.job(2)
+        self.assertEqual(job["time"]["start"]["number"], 2000)
+
+    def test_job_not_found(self):
+        """No records in either source -> SlurmrestdNotFoundError."""
+        with mock.patch.object(
+            self.slurmrestd,
+            "_request",
+            side_effect=lambda component, *a, **k: [],
+        ):
+            with self.assertRaises(SlurmrestdNotFoundError):
+                self.slurmrestd.job(3)
+
+    def test_job_without_accounting(self):
+        """Accounting is optional: when the slurmdb query fails because the
+        cluster has no slurmdbd, job detail is served from slurmctld alone
+        instead of propagating the error."""
+        ctld = [
+            {
+                "job_id": 4,
+                "array_task_id": {"set": False, "number": 0},
+                "start_time": {"number": 7000},
+                "job_state": ["RUNNING"],
+            }
+        ]
+
+        def fake(component, *args, **kwargs):
+            if component == "slurmdb":
+                raise SlurmrestdNotFoundError("no slurmdbd")
+            return ctld
+
+        with mock.patch.object(self.slurmrestd, "_request", side_effect=fake):
+            job = self.slurmrestd.job(4)  # must not raise
+        self.assertIsInstance(job, dict)
 
     @all_slurm_api_versions
     def test_nodes(self, slurm_version, api_version):


### PR DESCRIPTION
> **TL;DR** — The job-detail view returns incorrect, internally-contradictory data for any job whose id maps to more than one record: array jobs (each task is its own record), requeued/preempted jobs (multiple lifecycle records), and reused job-ids (slurmdbd is keyed by a recyclable id). `SlurmrestdFiltered.job()` takes the first element of the slurmctld and slurmdbd job lists and blindly `dict.update()`-merges them, so it can splice the live state of one task onto the accounting of an entirely unrelated job (and `IndexError`-crashes on jobs that have aged out of slurmctld). This change selects *coherent* records instead — the live task plus the accounting record for that same task/run — and handles the aged-out case cleanly. Single-record jobs (the common case) are unaffected.

## Problem

`SlurmrestdFiltered.job()` builds the job-detail object by taking the **first element** (`[0]`) of the slurmdbd and slurmctld job lists and blindly merging them:

```python
result = self._acctjob(job_id)             # _request("slurmdb", f"job/{id}", "jobs")[0]
result.update(self._ctldjob(job_id, ...))  # _request("slurm",  f"job/{id}", "jobs")[0]
```

This assumes `GET /job/{id}` returns exactly one record. It does not whenever a job-id maps to multiple records:

- **array jobs** — each task is a separate record (tasks also carry distinct internal job-ids);
- **requeued / preempted / restarted jobs** — multiple lifecycle records;
- **reused job-ids** — slurmdbd is keyed by job-id, which Slurm recycles.

`[0]` then picks an arbitrary record and `dict.update()` mashes two unrelated records into one. We hit this in production: `GET /job/<id>` showed a job displayed as RUNNING (the live array task) carrying the end-time / exit-code of a *different* job from a month earlier that had reused that id — a self-contradictory detail page. (For jobs aged out of slurmctld, `_ctldjob`'s `[0]` can also raise `IndexError` rather than returning a clean not-found.)

## Fix

Select **coherent** records instead of `[0]`:

- the slurmctld record (most-recently-started still-queued task) is authoritative for current state;
- the slurmdbd record merged in is the one describing the **same** task/run (matched by internal job-id + array task-id, latest start to skip requeue duplicates);
- **accounting is optional**: if the slurmdb query errors or 404s (no slurmdbd), job detail is served from slurmctld alone (the previous code seeded from slurmdbd with no fallback);
- if the job has aged out of slurmctld, fall back to the most-recent accounting record — and no `IndexError`.

Single-record jobs (the common case) are unaffected: one record in each list → identical result.

## Tests

Adds four tests to `TestSlurmrestdFiltered` (mocking `_request` keyed on component, so no version-specific fixtures): multi-record coherence, aged-out-of-slurmctld, not-found, and no-accounting.

---
*Co-authored with Claude Code (Anthropic). Opened as a draft pending CI + the CLA signature.*
