### PR TITLE
ci: tag with major version only on containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,6 +35,7 @@ jobs:
       # triggered the workflow:
       # - full semantic version, for example 7.0.0
       # - floating minor release tag, for example 7.0
+      # - floating major release tag, for example 7
       # - moving latest tag for the latest published release
       # - source git tag preserved as an image tag
       - name: Extract Docker metadata (agent)
@@ -45,6 +46,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest
             type=ref,event=tag
 
@@ -56,6 +58,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest
             type=ref,event=tag
 


### PR DESCRIPTION
This way, images can be updated while sticking on a specific major release, in the same manner as system packages in distribution repositories.

See https://github.com/rackslab/Slurm-web/issues/749#issuecomment-4777382879 for context.